### PR TITLE
T06: Implement URL generation and request queueing pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Spring Boot 4.0.3 web application using Java 25 (LTS). Standalone project with its own git repository. Uses Maven with wrapper for build management.
+Spring Boot 4.0.3 web application using Java 25 (LTS). Standalone project with its own git repository. Uses Maven with wrapper for build management. Long-term goal is a stateful HTTP scanner driven by virtual-thread concurrency.
 
 ## Build and Run Commands
 
 ```bash
-# Build and run tests
+# Full CI-equivalent build (compile, checkstyle, tests, package)
+./mvnw clean verify
+
+# Build + install to the local Maven repo
 ./mvnw clean install
 
 # Run the application
@@ -18,17 +21,22 @@ Spring Boot 4.0.3 web application using Java 25 (LTS). Standalone project with i
 # Run tests only
 ./mvnw test
 
-# Run a single test class
+# Run a single test class / method
 ./mvnw test -Dtest=ClassName
-
-# Run a single test method
 ./mvnw test -Dtest=ClassName#methodName
+
+# Lint only (checkstyle is also bound to the validate phase, so it runs on every build)
+./mvnw checkstyle:check
 ```
+
+CI (`.github/workflows/ci.yml`) runs `./mvnw clean verify` on Ubuntu with Temurin 25 — match it locally to avoid CI-only failures.
+
+**Checkstyle gotcha:** `NewlineAtEndOfFile` requires every source file to end with a newline. Files written without one fail the `validate` phase before tests run.
 
 ## Code Conventions
 
 - Package: `com.statefulscanner` — all components go in this package or sub-packages
-- Java 25 features encouraged (records, sealed classes, pattern matching, virtual threads)
+- Java 25 features encouraged (records, sealed classes, pattern matching, virtual threads, unnamed variables `_`)
 - Spring Boot 4.x conventions (constructor injection, `@RestController`, `application.yml`)
 - H2 in-memory database for development (runtime scope)
 
@@ -40,6 +48,11 @@ com.statefulscanner/
 ├── config/
 │   ├── ExecutorConfig.java           # Virtual thread executor bean + graceful shutdown
 │   └── HttpClientConfig.java         # java.net.http.HttpClient bean (HTTP/2, virtual threads)
+├── core/
+│   ├── UrlGenerator.java             # Combine base URL + wordlist entry → absolute URL
+│   └── RequestQueue.java             # Bounded BlockingQueue<ScanRequest> with backpressure
+├── model/
+│   └── ScanRequest.java              # Immutable record — one unit of scan work
 ├── exception/
 │   └── HttpRetryExhaustedException.java  # Thrown when retry attempts are exhausted
 ├── health/
@@ -49,9 +62,37 @@ com.statefulscanner/
     └── WordlistService.java          # Streaming wordlist file reader with dedup and CSV support
 ```
 
-**Concurrency model:** Virtual threads via `Executors.newVirtualThreadPerTaskExecutor()`. One executor bean shared across the app. Graceful shutdown with 30-second timeout in `@PreDestroy`. Avoid `synchronized` blocks — use `java.util.concurrent` structures to prevent virtual thread pinning.
+### Scanner pipeline (the big picture)
 
-**Testing approach:** `ExecutorConfigTest` is a plain unit test (no Spring context) — instantiates `ExecutorConfig` directly. Use `@SpringBootTest` only when testing Spring wiring. AssertJ is the preferred assertion library.
+The scanner is a producer-consumer pipeline. Each stage owns one transformation and knows nothing about its neighbours:
+
+```
+filepath ──► WordlistService ──► Stream<String>
+                                       │
+                                       ▼
+                                 UrlGenerator ──► ScanRequest
+                                                       │
+                                                       ▼
+                                                 RequestQueue   (buffer + backpressure)
+                                                       │
+                                                       ▼
+                                                 HttpRequestService ──► CompletableFuture<HttpResponse>
+```
+
+`ScanRequest` is the unit of work that flows from URL generation through the queue to HTTP execution. `RequestQueue` is the only stateful coordination primitive in the pipeline — everything else is a stateless transformation. Classes in `core/` are deliberately **not** Spring beans: their lifetime and parameters (base URL, queue capacity) are scan-specific, so an orchestrator service constructs them per scan instead.
+
+### Concurrency model
+
+Virtual threads via `Executors.newVirtualThreadPerTaskExecutor()`. One executor bean is shared across the app, with a 30-second graceful-shutdown window in `@PreDestroy`. **Avoid `synchronized` blocks** — use `java.util.concurrent` structures (`LinkedBlockingQueue`, `ReentrantLock`-backed primitives) so blocking calls unmount carrier threads instead of pinning them.
+
+## Testing
+
+- **Plain unit vs. Spring test:** instantiate classes directly when testing logic. `ExecutorConfigTest` is a plain unit test (no Spring context). Use `@SpringBootTest` only when verifying Spring wiring.
+- **AssertJ** is the preferred assertion library.
+- **Class-level `@Timeout(5, TimeUnit.SECONDS)`** is the project convention — caps any hung test.
+- **`@Nested` groups** organize related cases inside large test classes (see `UrlGeneratorTest`, `RequestQueueTest`).
+- **`@AfterEach` cleanup** for any closeable resource the test opens (streams, executors). Tests that leak `ExecutorService` instances cause flaky teardown.
+- **Concurrency assertions:** verify "still blocked" with bounded `Future.get(timeout)` expecting `TimeoutException`, not `Thread.sleep + isDone()`. When asserting "exactly once" delivery, use code-assigned UUIDs (e.g. `ScanRequest.id()`) as the dedup key, not construction-unique strings.
 
 ## Dependencies
 
@@ -60,3 +101,4 @@ com.statefulscanner/
 - `spring-boot-starter-actuator` — Health checks, metrics, `/actuator/health` endpoint
 - `spring-boot-starter-test` — JUnit 5 + Mockito + AssertJ (test scope)
 - `h2` — In-memory database (runtime scope)
+- Maven plugins: `maven-checkstyle-plugin` (validate phase), `jacoco-maven-plugin` (test phase coverage report)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,8 @@ filepath ──► WordlistService ──► Stream<String>
 
 `ScanRequest` is the unit of work that flows from URL generation through the queue to HTTP execution. `RequestQueue` is the only stateful coordination primitive in the pipeline — everything else is a stateless transformation. Classes in `core/` are deliberately **not** Spring beans: their lifetime and parameters (base URL, queue capacity) are scan-specific, so an orchestrator service constructs them per scan instead.
 
+**Not yet wired:** the orchestrator that drives this pipeline per scan — pumping wordlist entries through `UrlGenerator.generateRequests(Stream<String>)` into `RequestQueue`, then draining the queue (`dequeue` / `drainTo`) into `HttpRequestService` — does not exist yet. Today each stage is built and tested in isolation; nothing composes them end to end.
+
 ### Concurrency model
 
 Virtual threads via `Executors.newVirtualThreadPerTaskExecutor()`. One executor bean is shared across the app, with a 30-second graceful-shutdown window in `@PreDestroy`. **Avoid `synchronized` blocks** — use `java.util.concurrent` structures (`LinkedBlockingQueue`, `ReentrantLock`-backed primitives) so blocking calls unmount carrier threads instead of pinning them.

--- a/src/main/java/com/statefulscanner/core/RequestQueue.java
+++ b/src/main/java/com/statefulscanner/core/RequestQueue.java
@@ -1,0 +1,198 @@
+package com.statefulscanner.core;
+
+import com.statefulscanner.model.ScanRequest;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Bounded thread-safe queue of {@link ScanRequest} items, used as the hand-off
+ * point between URL-producing producers and HTTP-consuming workers.
+ *
+ * <p>Backed by a {@link LinkedBlockingQueue} with a fixed capacity. Producers
+ * call {@link #enqueue(ScanRequest)} (blocking), {@link #tryEnqueue(ScanRequest)}
+ * (non-blocking), or {@link #tryEnqueue(ScanRequest, Duration)} (bounded wait).
+ * Consumers call {@link #dequeue()} or {@link #tryDequeue(Duration)}.
+ *
+ * <h2>Capacity guidance</h2>
+ * Pick capacity based on expected memory pressure and the desired backpressure
+ * window — each {@code ScanRequest} is small (~200 bytes), so the default of
+ * {@value #DEFAULT_CAPACITY} costs roughly 200 KB at full saturation. Increase
+ * for very fast wordlists where producers should run ahead of consumers; lower
+ * for tight memory budgets or to surface backpressure faster.
+ *
+ * <h2>Lifecycle</h2>
+ * This queue does <strong>not</strong> implement an end-of-stream signal. When
+ * producers finish, consumers blocking in {@link #dequeue()} will hang
+ * indefinitely. The orchestrator is expected to terminate consumers explicitly,
+ * either by interrupting their virtual threads (idiomatic for structured
+ * concurrency / {@code StructuredTaskScope}) or by switching them to
+ * {@link #tryDequeue(Duration)} once the producer side is known to have closed.
+ *
+ * <h2>Thread-safety</h2>
+ * All operations are safe for concurrent use by virtual threads.
+ * {@link LinkedBlockingQueue} uses {@link java.util.concurrent.locks.ReentrantLock}
+ * internally, whose blocking methods do <em>not</em> pin the carrier thread on
+ * Java 21+, so this class is safe for the project's all-virtual-threads model.
+ * No {@code synchronized} blocks are used.
+ */
+public final class RequestQueue {
+
+    /** Default capacity when none is specified. */
+    public static final int DEFAULT_CAPACITY = 1024;
+
+    private final BlockingQueue<ScanRequest> queue;
+    private final int capacity;
+
+    /** Creates a queue with {@link #DEFAULT_CAPACITY}. */
+    public RequestQueue() {
+        this(DEFAULT_CAPACITY);
+    }
+
+    /**
+     * @param capacity maximum number of items the queue can hold; must be positive
+     * @throws IllegalArgumentException if {@code capacity <= 0}
+     */
+    public RequestQueue(int capacity) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("capacity must be positive: " + capacity);
+        }
+        this.capacity = capacity;
+        this.queue = new LinkedBlockingQueue<>(capacity);
+    }
+
+    /**
+     * Inserts the request, waiting indefinitely if the queue is full. This is the
+     * primary mechanism for producer backpressure.
+     *
+     * @param request the request to enqueue (non-null)
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     */
+    public void enqueue(ScanRequest request) throws InterruptedException {
+        Objects.requireNonNull(request, "request must not be null");
+        queue.put(request);
+    }
+
+    /**
+     * Inserts the request if space is immediately available.
+     *
+     * @param request the request to enqueue (non-null)
+     * @return {@code true} if the request was enqueued; {@code false} if the queue is full
+     */
+    public boolean tryEnqueue(ScanRequest request) {
+        Objects.requireNonNull(request, "request must not be null");
+        return queue.offer(request);
+    }
+
+    /**
+     * Inserts the request, waiting up to the given timeout if the queue is full.
+     * A zero timeout is equivalent to {@link #tryEnqueue(ScanRequest)}.
+     *
+     * @param request the request to enqueue (non-null)
+     * @param timeout maximum time to wait (non-null, non-negative); huge durations
+     *                that would overflow nanoseconds are clamped to {@link Long#MAX_VALUE}
+     *                nanoseconds (~292 years), which is effectively unbounded
+     * @return {@code true} if the request was enqueued before the timeout elapsed
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     */
+    public boolean tryEnqueue(ScanRequest request, Duration timeout) throws InterruptedException {
+        Objects.requireNonNull(request, "request must not be null");
+        Objects.requireNonNull(timeout, "timeout must not be null");
+        if (timeout.isNegative()) {
+            throw new IllegalArgumentException("timeout must not be negative: " + timeout);
+        }
+        return queue.offer(request, toNanosClamped(timeout), TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Retrieves and removes the head of the queue, waiting if necessary until an
+     * item is available.
+     *
+     * @return the head of the queue
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     */
+    public ScanRequest dequeue() throws InterruptedException {
+        return queue.take();
+    }
+
+    /**
+     * Retrieves and removes the head of the queue, waiting up to the given timeout.
+     * A zero timeout returns immediately, equivalent to a non-blocking poll.
+     *
+     * @param timeout maximum time to wait (non-null, non-negative); huge durations
+     *                that would overflow nanoseconds are clamped to {@link Long#MAX_VALUE}
+     *                nanoseconds (~292 years)
+     * @return the head of the queue, or {@code null} if the timeout elapsed before
+     *         an item became available
+     * @throws InterruptedException if the current thread is interrupted while waiting
+     */
+    public ScanRequest tryDequeue(Duration timeout) throws InterruptedException {
+        Objects.requireNonNull(timeout, "timeout must not be null");
+        if (timeout.isNegative()) {
+            throw new IllegalArgumentException("timeout must not be negative: " + timeout);
+        }
+        return queue.poll(toNanosClamped(timeout), TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Drains all currently available requests into {@code target} without blocking.
+     *
+     * @param target destination collection (non-null)
+     * @return the number of requests transferred
+     */
+    public int drainTo(Collection<? super ScanRequest> target) {
+        Objects.requireNonNull(target, "target must not be null");
+        return queue.drainTo(target);
+    }
+
+    /**
+     * Drains up to {@code maxElements} requests into {@code target} without blocking.
+     * Useful when consumers want to batch-process without risking unbounded growth
+     * of the receiving collection.
+     *
+     * @param target      destination collection (non-null)
+     * @param maxElements maximum number of items to transfer; must be non-negative.
+     *                    A value of zero is a no-op and returns {@code 0}.
+     * @return the number of requests transferred
+     */
+    public int drainTo(Collection<? super ScanRequest> target, int maxElements) {
+        Objects.requireNonNull(target, "target must not be null");
+        if (maxElements < 0) {
+            throw new IllegalArgumentException(
+                    "maxElements must not be negative: " + maxElements);
+        }
+        return queue.drainTo(target, maxElements);
+    }
+
+    /** @return the current number of queued requests. */
+    public int size() {
+        return queue.size();
+    }
+
+    /** @return the number of additional requests the queue can accept without blocking. */
+    public int remainingCapacity() {
+        return queue.remainingCapacity();
+    }
+
+    /** @return the configured maximum capacity. */
+    public int capacity() {
+        return capacity;
+    }
+
+    /** @return {@code true} if the queue currently holds no requests. */
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+
+    private static long toNanosClamped(Duration timeout) {
+        try {
+            return timeout.toNanos();
+        } catch (ArithmeticException _) {
+            return Long.MAX_VALUE;
+        }
+    }
+}

--- a/src/main/java/com/statefulscanner/core/UrlGenerator.java
+++ b/src/main/java/com/statefulscanner/core/UrlGenerator.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -38,6 +39,20 @@ import java.util.stream.Stream;
  * useful for endpoints that require a fixed query parameter (e.g. an API token)
  * but is a footgun if you intended the query/fragment to apply only to a probe
  * page. Strip them from the base URL beforehand if you need fresh probes.
+ *
+ * <p><strong>Userinfo carry-over:</strong> credentials embedded in the base URL
+ * ({@code https://user:pw@host}) are likewise preserved and forwarded on
+ * <em>every</em> generated URL — they are sent to every probed path, not just the
+ * base probe. Strip userinfo from the base URL if that is not intended.
+ *
+ * <h2>Destination filtering — none (SSRF surface)</h2>
+ * This class applies <strong>no</strong> filtering to the target host. A base URL
+ * pointing at a loopback address ({@code 127.0.0.1}), an RFC 1918 private range,
+ * link-local space, or a cloud metadata endpoint ({@code 169.254.169.254}) is
+ * accepted and turned into requests like any other host. For an authorized
+ * internal scan that is intended; but when a base URL can originate from an
+ * untrusted source, the caller is responsible for allow-listing or rejecting such
+ * destinations — {@code UrlGenerator} performs no such checks itself.
  *
  * <h2>Normalization &amp; encoding</h2>
  * Generated URLs are produced via the multi-argument {@link URI} constructor,
@@ -75,6 +90,14 @@ public final class UrlGenerator {
     public static final int MAX_URL_LENGTH = 8192;
 
     private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
+
+    /**
+     * Pre-compiled matcher for runs of two or more slashes. Compiled once and
+     * reused: {@link String#replaceAll(String, String)} recompiles its regex on
+     * every call, which is wasteful on the per-entry hot path that processes a
+     * whole wordlist.
+     */
+    private static final Pattern SLASH_RUN = Pattern.compile("/{2,}");
 
     private final URI baseUri;
     private final String pattern;
@@ -259,6 +282,6 @@ public final class UrlGenerator {
     }
 
     private static String collapseSlashes(String path) {
-        return path.replaceAll("/{2,}", "/");
+        return SLASH_RUN.matcher(path).replaceAll("/");
     }
 }

--- a/src/main/java/com/statefulscanner/core/UrlGenerator.java
+++ b/src/main/java/com/statefulscanner/core/UrlGenerator.java
@@ -1,0 +1,264 @@
+package com.statefulscanner.core;
+
+import com.statefulscanner.model.ScanRequest;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Generates absolute target URLs by combining a fixed base URL with wordlist entries,
+ * optionally substituting them into a path template.
+ *
+ * <h2>Pattern syntax</h2>
+ * Patterns are plain strings containing the literal placeholder {@value #PLACEHOLDER}
+ * which is replaced by the wordlist entry. Examples (base = {@code https://example.com}):
+ * <ul>
+ *   <li>pattern {@code null} or empty &rarr; {@code https://example.com/<entry>}</li>
+ *   <li>pattern {@code /admin/{WORD}} &rarr; {@code https://example.com/admin/<entry>}</li>
+ *   <li>pattern {@code /api/{WORD}/users} &rarr; {@code https://example.com/api/<entry>/users}</li>
+ * </ul>
+ * A non-null, non-empty pattern must contain {@value #PLACEHOLDER}; otherwise the
+ * constructor throws {@link IllegalArgumentException} (a pattern with no substitution
+ * point would generate the same URL for every wordlist entry, which is never the
+ * caller's intent). Multiple occurrences of the placeholder are all replaced.
+ *
+ * <h2>Base URL handling</h2>
+ * The base URL is parsed with the lenient single-argument {@link URI} constructor,
+ * so it must already be syntactically valid per RFC 3986 — pre-encode any reserved
+ * characters in user-supplied bases before passing them in. The scheme must be
+ * {@code http} or {@code https} (case-insensitive), and a host is required.
+ *
+ * <p><strong>Query &amp; fragment carry-over:</strong> if the base URL contains a
+ * query string or fragment, every generated URL carries them forward. This is
+ * useful for endpoints that require a fixed query parameter (e.g. an API token)
+ * but is a footgun if you intended the query/fragment to apply only to a probe
+ * page. Strip them from the base URL beforehand if you need fresh probes.
+ *
+ * <h2>Normalization &amp; encoding</h2>
+ * Generated URLs are produced via the multi-argument {@link URI} constructor,
+ * which percent-encodes path characters that are illegal in URI syntax (RFC 3986).
+ * Callers should provide raw, unencoded entries — pre-encoded sequences will be
+ * double-encoded. Consecutive {@code /} characters in the path are collapsed to a
+ * single slash <em>before</em> encoding, so multi-segment entries like
+ * {@code a//b///c} become {@code a/b/c}.
+ *
+ * <p><strong>Control characters are rejected.</strong> Wordlist entries containing
+ * any character below U+0020 or U+007F (DEL) cause {@link #generateUrl(String)} to
+ * throw {@link IllegalArgumentException}. Raw {@code URI} would silently percent-encode
+ * these (e.g. CRLF &rarr; {@code %0D%0A}); for a security tool that is the wrong
+ * default — a malicious wordlist could otherwise smuggle CR/LF or NUL bytes into
+ * downstream HTTP processing. Reject explicitly, defence-in-depth.
+ *
+ * <h2>Length cap</h2>
+ * The generated URL is rejected if it exceeds {@link #MAX_URL_LENGTH} characters.
+ * The cap is also pre-checked against the raw entry to avoid allocating a multi-megabyte
+ * string from a pathological wordlist line.
+ *
+ * <h2>Thread-safety</h2>
+ * Instances are immutable and safe for concurrent use by virtual threads.
+ */
+public final class UrlGenerator {
+
+    /** Placeholder token recognised inside path patterns. */
+    public static final String PLACEHOLDER = "{WORD}";
+
+    /**
+     * Hard upper bound on the length of a generated URL. The HTTP spec sets no
+     * limit but most servers/proxies (and the default Tomcat config) reject
+     * request lines beyond ~8 KB.
+     */
+    public static final int MAX_URL_LENGTH = 8192;
+
+    private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
+
+    private final URI baseUri;
+    private final String pattern;
+
+    /**
+     * Creates a generator that simply appends each wordlist entry to the base URL's path.
+     *
+     * @param baseUrl absolute http(s) URL with a host (e.g. {@code https://example.com})
+     * @throws IllegalArgumentException if {@code baseUrl} is malformed, missing a host,
+     *                                  or uses a scheme other than {@code http}/{@code https}
+     */
+    public UrlGenerator(String baseUrl) {
+        this(baseUrl, null);
+    }
+
+    /**
+     * Creates a generator that substitutes wordlist entries into the given pattern
+     * before appending to the base URL's path.
+     *
+     * @param baseUrl absolute http(s) URL with a host
+     * @param pattern path template containing {@value #PLACEHOLDER}, or {@code null}/empty
+     *                to append entries directly
+     * @throws IllegalArgumentException if {@code baseUrl} is invalid or
+     *                                  {@code pattern} is non-empty but contains no placeholder
+     */
+    public UrlGenerator(String baseUrl, String pattern) {
+        Objects.requireNonNull(baseUrl, "baseUrl must not be null");
+        this.baseUri = parseAndValidateBase(baseUrl);
+        this.pattern = (pattern == null || pattern.isEmpty()) ? null : validatePattern(pattern);
+    }
+
+    /**
+     * Builds an absolute URL for the given wordlist entry.
+     *
+     * @param wordlistEntry the entry to combine with the base URL; whitespace is trimmed
+     * @return the absolute, normalized, percent-encoded URL
+     * @throws IllegalArgumentException if {@code wordlistEntry} is blank, contains a
+     *                                  control character (&lt; U+0020 or U+007F),
+     *                                  the resulting URL is syntactically invalid, or
+     *                                  it exceeds {@link #MAX_URL_LENGTH}
+     */
+    public String generateUrl(String wordlistEntry) {
+        Objects.requireNonNull(wordlistEntry, "wordlistEntry must not be null");
+        String entry = wordlistEntry.trim();
+        if (entry.isEmpty()) {
+            throw new IllegalArgumentException("wordlistEntry must not be blank");
+        }
+        rejectControlCharacters(entry);
+        // Cheap pre-check before we build any larger strings — a wordlist line itself
+        // longer than the URL cap can't possibly produce a compliant URL.
+        if (entry.length() > MAX_URL_LENGTH) {
+            throw new IllegalArgumentException(
+                    "wordlistEntry exceeds maximum length of " + MAX_URL_LENGTH
+                            + " characters: " + entry.length());
+        }
+
+        String segment = (pattern == null) ? entry : pattern.replace(PLACEHOLDER, entry);
+        String basePath = baseUri.getPath() == null ? "" : baseUri.getPath();
+        String combinedPath = combinePath(basePath, segment);
+        String normalizedPath = collapseSlashes(combinedPath);
+
+        URI generated;
+        try {
+            generated = new URI(
+                    baseUri.getScheme(),
+                    baseUri.getUserInfo(),
+                    baseUri.getHost(),
+                    baseUri.getPort(),
+                    normalizedPath,
+                    baseUri.getQuery(),
+                    baseUri.getFragment());
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(
+                    "Generated URL is syntactically invalid for entry '" + wordlistEntry + "': "
+                            + e.getMessage(), e);
+        }
+
+        String url = generated.toASCIIString();
+        if (url.length() > MAX_URL_LENGTH) {
+            throw new IllegalArgumentException(
+                    "Generated URL exceeds maximum length of " + MAX_URL_LENGTH
+                            + " characters: " + url.length());
+        }
+        return url;
+    }
+
+    /**
+     * Builds a {@link ScanRequest} for the given wordlist entry, combining the
+     * generated URL with correlation metadata.
+     *
+     * @param wordlistEntry the entry to combine with the base URL
+     * @return a populated {@code ScanRequest} carrying a fresh correlation id
+     * @throws IllegalArgumentException see {@link #generateUrl(String)}
+     */
+    public ScanRequest generateRequest(String wordlistEntry) {
+        String url = generateUrl(wordlistEntry);
+        return ScanRequest.of(url, wordlistEntry, baseUri.toASCIIString());
+    }
+
+    /**
+     * Maps a stream of wordlist entries to {@link ScanRequest} instances. The
+     * returned stream is lazy — each request is built on demand, which composes
+     * cleanly with {@code WordlistService.readWordlist(String)}.
+     *
+     * <p>If you want to keep going past the first malformed entry (e.g. log and
+     * skip), wrap {@link #generateRequest(String)} yourself with a try/catch
+     * inside {@code map}; this method intentionally lets exceptions propagate so
+     * the default behaviour is fail-fast.
+     *
+     * @param entries non-null stream of wordlist entries
+     * @return a lazy stream of scan requests
+     */
+    public Stream<ScanRequest> generateRequests(Stream<String> entries) {
+        Objects.requireNonNull(entries, "entries must not be null");
+        return entries.map(this::generateRequest);
+    }
+
+    /** @return the base URL the generator was configured with, percent-encoded. */
+    public String baseUrl() {
+        return baseUri.toASCIIString();
+    }
+
+    /**
+     * @return the configured path template, or empty if the generator simply
+     *         appends entries to the base path
+     */
+    public Optional<String> pattern() {
+        return Optional.ofNullable(pattern);
+    }
+
+    private static URI parseAndValidateBase(String baseUrl) {
+        URI uri;
+        try {
+            uri = new URI(baseUrl);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid base URL: " + baseUrl, e);
+        }
+        if (!uri.isAbsolute()) {
+            throw new IllegalArgumentException("Base URL must be absolute: " + baseUrl);
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || !ALLOWED_SCHEMES.contains(scheme.toLowerCase(Locale.ROOT))) {
+            throw new IllegalArgumentException(
+                    "Base URL must use http or https scheme: " + baseUrl);
+        }
+        if (uri.getHost() == null || uri.getHost().isBlank()) {
+            throw new IllegalArgumentException("Base URL must have a host: " + baseUrl);
+        }
+        return uri;
+    }
+
+    private static String validatePattern(String pattern) {
+        if (!pattern.contains(PLACEHOLDER)) {
+            throw new IllegalArgumentException(
+                    "Pattern must contain placeholder " + PLACEHOLDER + ": " + pattern);
+        }
+        rejectControlCharacters(pattern);
+        return pattern;
+    }
+
+    private static void rejectControlCharacters(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c < 0x20 || c == 0x7F) {
+                throw new IllegalArgumentException(
+                        "Value contains control character at index " + i
+                                + " (U+" + String.format(Locale.ROOT, "%04X", (int) c) + ")");
+            }
+        }
+    }
+
+    private static String combinePath(String basePath, String segment) {
+        boolean baseEndsWithSlash = basePath.endsWith("/");
+        boolean segmentStartsWithSlash = segment.startsWith("/");
+        if (baseEndsWithSlash && segmentStartsWithSlash) {
+            return basePath + segment.substring(1);
+        }
+        if (!baseEndsWithSlash && !segmentStartsWithSlash) {
+            return basePath + "/" + segment;
+        }
+        return basePath + segment;
+    }
+
+    private static String collapseSlashes(String path) {
+        return path.replaceAll("/{2,}", "/");
+    }
+}

--- a/src/main/java/com/statefulscanner/model/ScanRequest.java
+++ b/src/main/java/com/statefulscanner/model/ScanRequest.java
@@ -1,0 +1,54 @@
+package com.statefulscanner.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * An immutable scan request carrying a fully resolved target URL plus the
+ * context needed to correlate the request with its source wordlist entry.
+ *
+ * <p>Instances are produced by
+ * {@link com.statefulscanner.core.UrlGenerator#generateRequest(String)} or via
+ * {@link #of(String, String, String)} when an orchestrator needs to construct
+ * one directly. Equality is value-based on all components (record default), so
+ * two requests with different ids are never equal even if they target the same
+ * URL — this is intentional, since the id correlates a specific in-flight
+ * attempt with its eventual response.
+ *
+ * <p><strong>Validation:</strong> {@code id}, {@code url}, {@code wordlistEntry},
+ * and {@code baseUrl} are all required to be non-null. {@code url} must also be
+ * non-blank because it is the only field consumers rely on for actually
+ * dispatching work. {@code wordlistEntry} is intentionally <em>not</em> blank-checked
+ * — callers may legitimately produce a request from a single-character or otherwise
+ * unusual entry, and any blank-rejection should happen at the producing layer
+ * (e.g. {@link com.statefulscanner.core.UrlGenerator#generateUrl(String)}).
+ *
+ * @param id            unique correlation id (used for logging / response join)
+ * @param url           the absolute URL to fetch; non-blank
+ * @param wordlistEntry the original (untrimmed) wordlist entry that produced the URL
+ * @param baseUrl       the base URL the entry was combined with
+ */
+public record ScanRequest(UUID id, String url, String wordlistEntry, String baseUrl) {
+
+    public ScanRequest {
+        Objects.requireNonNull(id, "id must not be null");
+        Objects.requireNonNull(url, "url must not be null");
+        Objects.requireNonNull(wordlistEntry, "wordlistEntry must not be null");
+        Objects.requireNonNull(baseUrl, "baseUrl must not be null");
+        if (url.isBlank()) {
+            throw new IllegalArgumentException("url must not be blank");
+        }
+    }
+
+    /**
+     * Convenience factory that assigns a fresh random {@link UUID}.
+     *
+     * @param url           the absolute URL to fetch (non-blank)
+     * @param wordlistEntry the wordlist entry that produced the URL (non-null)
+     * @param baseUrl       the base URL combined with the entry (non-null)
+     * @return a new {@code ScanRequest} with a freshly generated id
+     */
+    public static ScanRequest of(String url, String wordlistEntry, String baseUrl) {
+        return new ScanRequest(UUID.randomUUID(), url, wordlistEntry, baseUrl);
+    }
+}

--- a/src/test/java/com/statefulscanner/core/RequestQueueTest.java
+++ b/src/test/java/com/statefulscanner/core/RequestQueueTest.java
@@ -1,0 +1,614 @@
+package com.statefulscanner.core;
+
+import com.statefulscanner.model.ScanRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
+class RequestQueueTest {
+
+    private ExecutorService executor;
+
+    @AfterEach
+    void tearDown() {
+        if (executor != null) {
+            // ExecutorService.close() (Java 19+) waits for in-flight tasks to
+            // finish, then shuts the executor down — adequate cleanup per the
+            // project's "always close AutoCloseables in @AfterEach" rule.
+            executor.close();
+        }
+    }
+
+    private static ScanRequest sample(String entry) {
+        return ScanRequest.of("https://example.com/" + entry, entry, "https://example.com");
+    }
+
+    /**
+     * Asserts that the given future has not yet completed, by attempting a
+     * short bounded wait and expecting it to time out. This is the canonical
+     * sleep-free way to verify "still blocked": we never busy-wait, and we
+     * never assume "fast enough" on a slow CI — if the future does complete
+     * within the wait window, that itself is the failure signal.
+     */
+    private static void assertStillBlocked(Future<?> future) {
+        assertThatThrownBy(() -> future.get(100, TimeUnit.MILLISECONDS))
+                .as("future should still be blocked")
+                .isInstanceOf(TimeoutException.class);
+    }
+
+    @Nested
+    class Construction {
+
+        @ParameterizedTest
+        @ValueSource(ints = {0, -1, -100, Integer.MIN_VALUE})
+        void constructor_withNonPositiveCapacity_throwsIllegalArgumentException(int capacity) {
+            assertThatThrownBy(() -> new RequestQueue(capacity))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("positive");
+        }
+
+        @Test
+        void defaultConstructor_usesDefaultCapacity() {
+            RequestQueue queue = new RequestQueue();
+
+            assertThat(queue.capacity()).isEqualTo(RequestQueue.DEFAULT_CAPACITY);
+        }
+
+        @Test
+        void constructor_storesCapacity() {
+            RequestQueue queue = new RequestQueue(7);
+
+            assertThat(queue.capacity()).isEqualTo(7);
+            assertThat(queue.remainingCapacity()).isEqualTo(7);
+            assertThat(queue.size()).isZero();
+            assertThat(queue.isEmpty()).isTrue();
+        }
+    }
+
+    @Nested
+    class BasicOperations {
+
+        @Test
+        void enqueue_thenDequeue_returnsSameRequest() throws Exception {
+            RequestQueue queue = new RequestQueue(4);
+            ScanRequest request = sample("admin");
+
+            queue.enqueue(request);
+
+            assertThat(queue.size()).isEqualTo(1);
+            assertThat(queue.dequeue()).isEqualTo(request);
+            assertThat(queue.isEmpty()).isTrue();
+        }
+
+        @Test
+        void enqueue_preservesFifoOrder() throws Exception {
+            RequestQueue queue = new RequestQueue(4);
+            ScanRequest a = sample("a");
+            ScanRequest b = sample("b");
+            ScanRequest c = sample("c");
+
+            queue.enqueue(a);
+            queue.enqueue(b);
+            queue.enqueue(c);
+
+            assertThat(queue.dequeue()).isEqualTo(a);
+            assertThat(queue.dequeue()).isEqualTo(b);
+            assertThat(queue.dequeue()).isEqualTo(c);
+        }
+
+        @Test
+        void enqueue_withNullRequest_throwsNullPointerException() {
+            RequestQueue queue = new RequestQueue(2);
+
+            assertThatThrownBy(() -> queue.enqueue(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void tryEnqueue_withNullRequest_throwsNullPointerException() {
+            RequestQueue queue = new RequestQueue(2);
+
+            assertThatThrownBy(() -> queue.tryEnqueue(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void tryEnqueueWithTimeout_withNullRequest_throwsNullPointerException() {
+            RequestQueue queue = new RequestQueue(2);
+
+            assertThatThrownBy(() -> queue.tryEnqueue(null, Duration.ofMillis(10)))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void tryEnqueueWithTimeout_withNullTimeout_throwsNullPointerException() {
+            RequestQueue queue = new RequestQueue(2);
+
+            assertThatThrownBy(() -> queue.tryEnqueue(sample("a"), null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void tryDequeue_withNullTimeout_throwsNullPointerException() {
+            RequestQueue queue = new RequestQueue(2);
+
+            assertThatThrownBy(() -> queue.tryDequeue(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Nested
+    class NonBlockingOps {
+
+        @Test
+        void tryEnqueue_returnsTrueWhenSpaceAvailable() {
+            RequestQueue queue = new RequestQueue(2);
+
+            assertThat(queue.tryEnqueue(sample("a"))).isTrue();
+        }
+
+        @Test
+        void tryEnqueue_returnsFalseWhenFull() {
+            RequestQueue queue = new RequestQueue(1);
+            queue.tryEnqueue(sample("a"));
+
+            assertThat(queue.tryEnqueue(sample("b"))).isFalse();
+            assertThat(queue.size()).isEqualTo(1);
+        }
+
+        @Test
+        void tryEnqueueWithTimeout_negativeTimeout_throwsIllegalArgumentException() {
+            RequestQueue queue = new RequestQueue(1);
+
+            assertThatThrownBy(() -> queue.tryEnqueue(sample("a"), Duration.ofMillis(-1)))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void tryEnqueueWithTimeout_returnsFalseWhenTimeoutElapses() throws Exception {
+            RequestQueue queue = new RequestQueue(1);
+            queue.enqueue(sample("a"));
+
+            assertThat(queue.tryEnqueue(sample("b"), Duration.ofMillis(50))).isFalse();
+            assertThat(queue.size()).isEqualTo(1);
+        }
+
+        @Test
+        void tryEnqueueWithTimeout_zeroDurationOnFullQueue_returnsFalseImmediately() throws Exception {
+            // Documented behaviour: a zero timeout is equivalent to a non-blocking
+            // try. Verify it doesn't accidentally fall through to indefinite waiting
+            // (e.g. a `0 -> Long.MAX_VALUE` clamp bug).
+            RequestQueue queue = new RequestQueue(1);
+            queue.enqueue(sample("a"));
+
+            assertThat(queue.tryEnqueue(sample("b"), Duration.ZERO)).isFalse();
+            assertThat(queue.size()).isEqualTo(1);
+        }
+
+        @Test
+        void tryEnqueueWithTimeout_zeroDurationOnAvailableQueue_returnsTrue() throws Exception {
+            RequestQueue queue = new RequestQueue(1);
+
+            assertThat(queue.tryEnqueue(sample("a"), Duration.ZERO)).isTrue();
+            assertThat(queue.size()).isEqualTo(1);
+        }
+
+        @Test
+        void tryDequeue_returnsNullWhenEmptyAndTimeoutElapses() throws Exception {
+            RequestQueue queue = new RequestQueue(1);
+
+            assertThat(queue.tryDequeue(Duration.ofMillis(50))).isNull();
+        }
+
+        @Test
+        void tryDequeue_negativeTimeout_throwsIllegalArgumentException() {
+            RequestQueue queue = new RequestQueue(1);
+
+            assertThatThrownBy(() -> queue.tryDequeue(Duration.ofMillis(-1)))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void tryDequeue_returnsItemWhenAvailable() throws Exception {
+            RequestQueue queue = new RequestQueue(1);
+            ScanRequest a = sample("a");
+            queue.enqueue(a);
+
+            assertThat(queue.tryDequeue(Duration.ofMillis(10))).isEqualTo(a);
+        }
+
+        @Test
+        void tryDequeue_zeroDurationOnEmptyQueue_returnsNullImmediately() throws Exception {
+            RequestQueue queue = new RequestQueue(1);
+
+            assertThat(queue.tryDequeue(Duration.ZERO)).isNull();
+        }
+
+        @Test
+        void tryDequeue_zeroDurationOnAvailableQueue_returnsItem() throws Exception {
+            RequestQueue queue = new RequestQueue(1);
+            ScanRequest a = sample("a");
+            queue.enqueue(a);
+
+            assertThat(queue.tryDequeue(Duration.ZERO)).isEqualTo(a);
+        }
+    }
+
+    @Nested
+    class BlockingBehaviour {
+
+        @Test
+        void enqueue_blocksWhenFull_unblocksAfterDequeue() throws Exception {
+            RequestQueue queue = new RequestQueue(1);
+            queue.enqueue(sample("first"));
+
+            executor = Executors.newVirtualThreadPerTaskExecutor();
+            CountDownLatch started = new CountDownLatch(1);
+
+            Future<Void> producer = executor.submit(() -> {
+                started.countDown();
+                queue.enqueue(sample("second"));
+                return null;
+            });
+
+            // Wait for the producer task to actually start running.
+            started.await();
+            // Verify the producer is still blocked. We use a bounded Future.get
+            // expecting TimeoutException rather than a Thread.sleep + isDone()
+            // pair: the bounded wait gives the producer ample time to either
+            // complete (which would be the bug) or stay blocked (the correct
+            // behaviour) without a fixed sleep.
+            assertStillBlocked(producer);
+
+            assertThat(queue.dequeue().wordlistEntry()).isEqualTo("first");
+            // Unblocked: producer should now finish promptly.
+            producer.get(1, TimeUnit.SECONDS);
+            assertThat(queue.size()).isEqualTo(1);
+            assertThat(queue.dequeue().wordlistEntry()).isEqualTo("second");
+        }
+
+        @Test
+        void dequeue_blocksWhenEmpty_unblocksAfterEnqueue() throws Exception {
+            RequestQueue queue = new RequestQueue(1);
+            executor = Executors.newVirtualThreadPerTaskExecutor();
+
+            CountDownLatch started = new CountDownLatch(1);
+            Future<ScanRequest> consumer = executor.submit(() -> {
+                started.countDown();
+                return queue.dequeue();
+            });
+
+            started.await();
+            assertStillBlocked(consumer);
+
+            ScanRequest request = sample("late");
+            queue.enqueue(request);
+
+            assertThat(consumer.get(1, TimeUnit.SECONDS)).isEqualTo(request);
+        }
+
+        @Test
+        void enqueue_propagatesInterrupt() throws Exception {
+            RequestQueue queue = new RequestQueue(1);
+            queue.enqueue(sample("blocker"));
+            executor = Executors.newVirtualThreadPerTaskExecutor();
+
+            CountDownLatch started = new CountDownLatch(1);
+            // Capture the running thread so we can interrupt it directly. Cancelling
+            // the Future works too, but ExecutorService.cancel() reports the task
+            // as cancelled regardless of whether the body actually observed the
+            // interrupt — which means the previous version of this test couldn't
+            // distinguish "InterruptedException was thrown" from "task was just
+            // cancelled before it ran". Capturing the thread + assertions on the
+            // actual exception fixes that.
+            AtomicReference<Thread> producerThread = new AtomicReference<>();
+            Future<Void> producer = executor.submit(() -> {
+                producerThread.set(Thread.currentThread());
+                started.countDown();
+                queue.enqueue(sample("blocked")); // expected to throw InterruptedException
+                return null;
+            });
+
+            started.await();
+            // Give the producer a window to actually enter put() and block. We
+            // confirm "still blocked" via assertStillBlocked rather than a bare
+            // sleep — and crucially, the resulting bounded wait both (a) proves
+            // the thread is parked in put() and (b) gives put() time to register
+            // its waiter before we deliver the interrupt.
+            assertStillBlocked(producer);
+
+            Thread t = producerThread.get();
+            assertThat(t).as("producer thread should be captured by now").isNotNull();
+            t.interrupt();
+
+            // The producer task body must surface InterruptedException to the
+            // caller — verify it does, rather than being silently swallowed.
+            assertThatThrownBy(() -> producer.get(1, TimeUnit.SECONDS))
+                    .isInstanceOf(ExecutionException.class)
+                    .hasCauseInstanceOf(InterruptedException.class);
+
+            // The blocker holder is still queued; the interrupted enqueue was
+            // never delivered, so size remains at the pre-interrupt state.
+            assertThat(queue.size()).isEqualTo(1);
+            assertThat(queue.dequeue().wordlistEntry()).isEqualTo("blocker");
+        }
+    }
+
+    @Nested
+    class Drain {
+
+        @Test
+        void drainTo_movesAllItems() {
+            RequestQueue queue = new RequestQueue(4);
+            queue.tryEnqueue(sample("a"));
+            queue.tryEnqueue(sample("b"));
+            queue.tryEnqueue(sample("c"));
+
+            List<ScanRequest> drained = new ArrayList<>();
+            int count = queue.drainTo(drained);
+
+            assertThat(count).isEqualTo(3);
+            assertThat(drained).extracting(ScanRequest::wordlistEntry)
+                    .containsExactly("a", "b", "c");
+            assertThat(queue.isEmpty()).isTrue();
+        }
+
+        @Test
+        void drainTo_emptyQueue_returnsZero() {
+            RequestQueue queue = new RequestQueue(4);
+            List<ScanRequest> drained = new ArrayList<>();
+
+            assertThat(queue.drainTo(drained)).isZero();
+            assertThat(drained).isEmpty();
+        }
+
+        @Test
+        void drainTo_withNullTarget_throwsNullPointerException() {
+            RequestQueue queue = new RequestQueue(1);
+
+            assertThatThrownBy(() -> queue.drainTo(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void drainTo_onPartiallyConsumedQueue_drainsRemainingItemsInOrder() throws Exception {
+            // After a partial dequeue, drainTo must transfer the *remaining*
+            // items in FIFO order — not all originally enqueued items, and not
+            // in some arbitrary order. This guards against a regression where
+            // drainTo accidentally snapshotted state at enqueue time.
+            RequestQueue queue = new RequestQueue(4);
+            queue.enqueue(sample("a"));
+            queue.enqueue(sample("b"));
+            queue.enqueue(sample("c"));
+            queue.enqueue(sample("d"));
+
+            assertThat(queue.dequeue().wordlistEntry()).isEqualTo("a");
+            assertThat(queue.dequeue().wordlistEntry()).isEqualTo("b");
+
+            List<ScanRequest> drained = new ArrayList<>();
+            int count = queue.drainTo(drained);
+
+            assertThat(count).isEqualTo(2);
+            assertThat(drained).extracting(ScanRequest::wordlistEntry)
+                    .containsExactly("c", "d");
+            assertThat(queue.isEmpty()).isTrue();
+        }
+
+        @Test
+        void drainToBounded_movesAtMostMaxItems() {
+            // Architect-added bounded variant: cap how many items the consumer
+            // pulls at once. Verify the cap is honoured AND the remaining items
+            // stay in the queue in their original order.
+            RequestQueue queue = new RequestQueue(8);
+            queue.tryEnqueue(sample("a"));
+            queue.tryEnqueue(sample("b"));
+            queue.tryEnqueue(sample("c"));
+            queue.tryEnqueue(sample("d"));
+            queue.tryEnqueue(sample("e"));
+
+            List<ScanRequest> drained = new ArrayList<>();
+            int count = queue.drainTo(drained, 3);
+
+            assertThat(count).isEqualTo(3);
+            assertThat(drained).extracting(ScanRequest::wordlistEntry)
+                    .containsExactly("a", "b", "c");
+            assertThat(queue.size()).isEqualTo(2);
+        }
+
+        @Test
+        void drainToBounded_withMaxLargerThanQueue_drainsEverything() {
+            RequestQueue queue = new RequestQueue(4);
+            queue.tryEnqueue(sample("a"));
+            queue.tryEnqueue(sample("b"));
+
+            List<ScanRequest> drained = new ArrayList<>();
+            int count = queue.drainTo(drained, 100);
+
+            assertThat(count).isEqualTo(2);
+            assertThat(drained).hasSize(2);
+            assertThat(queue.isEmpty()).isTrue();
+        }
+
+        @Test
+        void drainToBounded_withZeroMax_isNoop() {
+            RequestQueue queue = new RequestQueue(4);
+            queue.tryEnqueue(sample("a"));
+            queue.tryEnqueue(sample("b"));
+
+            List<ScanRequest> drained = new ArrayList<>();
+            int count = queue.drainTo(drained, 0);
+
+            assertThat(count).isZero();
+            assertThat(drained).isEmpty();
+            assertThat(queue.size()).isEqualTo(2);
+        }
+
+        @Test
+        void drainToBounded_withNegativeMax_throwsIllegalArgumentException() {
+            RequestQueue queue = new RequestQueue(4);
+            List<ScanRequest> drained = new ArrayList<>();
+
+            assertThatThrownBy(() -> queue.drainTo(drained, -1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("negative");
+        }
+
+        @Test
+        void drainToBounded_withNullTarget_throwsNullPointerException() {
+            RequestQueue queue = new RequestQueue(4);
+
+            assertThatThrownBy(() -> queue.drainTo(null, 5))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Nested
+    class Concurrency {
+
+        @Test
+        void concurrentProducersAndConsumers_deliverEachRequestExactlyOnce() throws Exception {
+            // "Exactly once" requires both: every enqueued request is delivered
+            // (no losses) AND no request is delivered more than once (no
+            // duplicates). The previous version of this test could only catch
+            // duplicates if the duplicate happened to push consumedCount past
+            // total — borderline. Switching the dedup key to ScanRequest.id()
+            // (a UUID generated per-request, guaranteed unique by construction)
+            // means the Set's final size precisely measures unique deliveries,
+            // and any duplicate delivery shows up immediately as a Set size
+            // smaller than the enqueued total.
+            int producerCount = 8;
+            int consumerCount = 8;
+            int perProducer = 500;
+            int total = producerCount * perProducer;
+
+            RequestQueue queue = new RequestQueue(64);
+            executor = Executors.newVirtualThreadPerTaskExecutor();
+
+            Set<UUID> consumedIds = java.util.concurrent.ConcurrentHashMap.newKeySet();
+            AtomicInteger consumedCount = new AtomicInteger();
+
+            List<Future<?>> consumers = new ArrayList<>();
+            for (int i = 0; i < consumerCount; i++) {
+                consumers.add(executor.submit(() -> {
+                    while (consumedCount.get() < total) {
+                        ScanRequest req = queue.tryDequeue(Duration.ofMillis(100));
+                        if (req != null) {
+                            consumedIds.add(req.id());
+                            consumedCount.incrementAndGet();
+                        }
+                    }
+                    return null;
+                }));
+            }
+
+            List<Future<?>> producers = new ArrayList<>();
+            for (int i = 0; i < producerCount; i++) {
+                final int producerIndex = i;
+                producers.add(executor.submit(() -> {
+                    for (int j = 0; j < perProducer; j++) {
+                        queue.enqueue(sample("p" + producerIndex + "-" + j));
+                    }
+                    return null;
+                }));
+            }
+
+            for (Future<?> f : producers) {
+                f.get(3, TimeUnit.SECONDS);
+            }
+            for (Future<?> f : consumers) {
+                f.get(3, TimeUnit.SECONDS);
+            }
+
+            // No losses: every produced request was observed.
+            assertThat(consumedCount.get()).isEqualTo(total);
+            // No duplicates: every observed id was unique.
+            assertThat(consumedIds).hasSize(total);
+            assertThat(queue.isEmpty()).isTrue();
+        }
+
+        @Test
+        void backpressure_producerBlocksWhenQueueFull() throws Exception {
+            int capacity = 4;
+            int totalToEnqueue = 100;
+            RequestQueue queue = new RequestQueue(capacity);
+            executor = Executors.newVirtualThreadPerTaskExecutor();
+
+            Future<?> producer = executor.submit(() -> {
+                for (int i = 0; i < totalToEnqueue; i++) {
+                    queue.enqueue(sample("e" + i));
+                }
+                return null;
+            });
+
+            // Drain slowly; queue.size() should never exceed capacity.
+            int observedMax = 0;
+            Set<String> seen = new HashSet<>();
+            for (int i = 0; i < totalToEnqueue; i++) {
+                observedMax = Math.max(observedMax, queue.size());
+                ScanRequest req = queue.dequeue();
+                seen.add(req.wordlistEntry());
+            }
+
+            producer.get(2, TimeUnit.SECONDS);
+            assertThat(observedMax).isLessThanOrEqualTo(capacity);
+            assertThat(seen).hasSize(totalToEnqueue);
+            assertThat(queue.isEmpty()).isTrue();
+        }
+
+        @Test
+        void concurrentEnqueueAndDrainTo_yieldsConsistentTotal() throws Exception {
+            // Interleave one producer with periodic drainTo() calls and verify
+            // every produced request is accounted for — either drained out or
+            // still resident in the queue at the end. This catches races where
+            // drainTo might double-count or skip an item that's mid-handoff.
+            int totalToEnqueue = 2_000;
+            RequestQueue queue = new RequestQueue(64);
+            executor = Executors.newVirtualThreadPerTaskExecutor();
+
+            Future<?> producer = executor.submit(() -> {
+                for (int i = 0; i < totalToEnqueue; i++) {
+                    queue.enqueue(sample("e" + i));
+                }
+                return null;
+            });
+
+            List<ScanRequest> drained = new ArrayList<>();
+            // Use bounded drain to exercise the (Collection, int) variant under
+            // concurrency, alongside the producer.
+            while (!producer.isDone() || !queue.isEmpty()) {
+                queue.drainTo(drained, 32);
+            }
+            // Final drain to clean up anything enqueued between the last loop
+            // iteration and the producer-done check.
+            queue.drainTo(drained);
+
+            producer.get(3, TimeUnit.SECONDS);
+            assertThat(drained).hasSize(totalToEnqueue);
+            assertThat(drained).extracting(ScanRequest::wordlistEntry).doesNotHaveDuplicates();
+            assertThat(queue.isEmpty()).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/statefulscanner/core/RequestQueueTest.java
+++ b/src/test/java/com/statefulscanner/core/RequestQueueTest.java
@@ -217,6 +217,22 @@ class RequestQueueTest {
         }
 
         @Test
+        void tryEnqueueWithTimeout_overflowingDuration_isClampedNotRejected() throws Exception {
+            // toNanosClamped: Duration.toNanos() throws ArithmeticException for any
+            // duration beyond ~292 years; the catch branch clamps to Long.MAX_VALUE
+            // nanos instead of letting that exception escape tryEnqueue. Note we use
+            // ofSeconds, not ofDays(Long.MAX_VALUE) — the latter overflows inside
+            // ofDays() itself, before toNanos() is ever reached. Exercised on a queue
+            // WITH space so offer() returns at once; the class @Timeout proves we did
+            // not actually wait out the clamp.
+            RequestQueue queue = new RequestQueue(1);
+
+            assertThat(queue.tryEnqueue(sample("a"), Duration.ofSeconds(Long.MAX_VALUE)))
+                    .isTrue();
+            assertThat(queue.size()).isEqualTo(1);
+        }
+
+        @Test
         void tryDequeue_returnsNullWhenEmptyAndTimeoutElapses() throws Exception {
             RequestQueue queue = new RequestQueue(1);
 
@@ -255,6 +271,18 @@ class RequestQueueTest {
 
             assertThat(queue.tryDequeue(Duration.ZERO)).isEqualTo(a);
         }
+
+        @Test
+        void tryDequeue_overflowingDuration_isClampedNotRejected() throws Exception {
+            // Dequeue-side mirror of the tryEnqueue clamp test: a timeout so large
+            // it overflows toNanos() is clamped rather than throwing, and on a
+            // non-empty queue poll() returns the head immediately.
+            RequestQueue queue = new RequestQueue(1);
+            ScanRequest a = sample("a");
+            queue.enqueue(a);
+
+            assertThat(queue.tryDequeue(Duration.ofSeconds(Long.MAX_VALUE))).isEqualTo(a);
+        }
     }
 
     @Nested
@@ -286,6 +314,38 @@ class RequestQueueTest {
             assertThat(queue.dequeue().wordlistEntry()).isEqualTo("first");
             // Unblocked: producer should now finish promptly.
             producer.get(1, TimeUnit.SECONDS);
+            assertThat(queue.size()).isEqualTo(1);
+            assertThat(queue.dequeue().wordlistEntry()).isEqualTo("second");
+        }
+
+        @Test
+        void tryEnqueueWithTimeout_blocksWhenFull_succeedsAfterDequeue() throws Exception {
+            // The fail-after-block path (timeout elapses -> false) is covered in
+            // NonBlockingOps; this covers the success-after-block path: the bounded
+            // wait parks on a full queue, then completes with true once a consumer
+            // frees a slot before the timeout.
+            RequestQueue queue = new RequestQueue(1);
+            queue.enqueue(sample("first"));
+
+            executor = Executors.newVirtualThreadPerTaskExecutor();
+            CountDownLatch started = new CountDownLatch(1);
+
+            // A generous timeout that cannot realistically elapse mid-test, so the
+            // only way this returns true is the space-freed path — not a
+            // timeout-then-retry fluke. The class-level @Timeout still caps the test.
+            Future<Boolean> producer = executor.submit(() -> {
+                started.countDown();
+                return queue.tryEnqueue(sample("second"), Duration.ofSeconds(30));
+            });
+
+            started.await();
+            // Confirm the producer is genuinely parked in offer() on the full queue.
+            assertStillBlocked(producer);
+
+            // Free a slot; the blocked tryEnqueue must now complete with true.
+            assertThat(queue.dequeue().wordlistEntry()).isEqualTo("first");
+
+            assertThat(producer.get(1, TimeUnit.SECONDS)).isTrue();
             assertThat(queue.size()).isEqualTo(1);
             assertThat(queue.dequeue().wordlistEntry()).isEqualTo("second");
         }

--- a/src/test/java/com/statefulscanner/core/UrlGeneratorTest.java
+++ b/src/test/java/com/statefulscanner/core/UrlGeneratorTest.java
@@ -1,0 +1,521 @@
+package com.statefulscanner.core;
+
+import com.statefulscanner.model.ScanRequest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
+class UrlGeneratorTest {
+
+    @Nested
+    class Construction {
+
+        @Test
+        void constructor_withNullBaseUrl_throwsNullPointerException() {
+            assertThatThrownBy(() -> new UrlGenerator(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"not a url", "://missing-scheme", "http://", "https://"})
+        void constructor_withMalformedBaseUrl_throwsIllegalArgumentException(String badUrl) {
+            assertThatThrownBy(() -> new UrlGenerator(badUrl))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void constructor_withRelativeUrl_throwsIllegalArgumentException() {
+            assertThatThrownBy(() -> new UrlGenerator("/path/only"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("absolute");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ftp://example.com", "file:///etc/passwd", "javascript:alert(1)"})
+        void constructor_withDisallowedScheme_throwsIllegalArgumentException(String badUrl) {
+            assertThatThrownBy(() -> new UrlGenerator(badUrl))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("http or https");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"http://example.com", "HTTP://example.com", "https://example.com",
+                "HTTPS://example.com"})
+        void constructor_acceptsHttpAndHttpsCaseInsensitive(String baseUrl) {
+            // Behaviour: scheme casing is accepted but NOT normalized — baseUrl()
+            // round-trips the input scheme verbatim. Asserting that exact
+            // round-trip prevents the test from silently passing on weaker
+            // implementations that just check non-blankness.
+            UrlGenerator generator = new UrlGenerator(baseUrl);
+
+            assertThat(generator.baseUrl()).isEqualTo(baseUrl);
+        }
+
+        @Test
+        void constructor_withPatternMissingPlaceholder_throwsIllegalArgumentException() {
+            assertThatThrownBy(() -> new UrlGenerator("https://example.com", "/admin/static"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("{WORD}");
+        }
+
+        @Test
+        void constructor_withNullPattern_treatsAsSimpleAppend() {
+            UrlGenerator generator = new UrlGenerator("https://example.com", null);
+
+            assertThat(generator.pattern()).isEmpty();
+            assertThat(generator.generateUrl("admin"))
+                    .isEqualTo("https://example.com/admin");
+        }
+
+        @Test
+        void constructor_withEmptyPattern_treatsAsSimpleAppend() {
+            UrlGenerator generator = new UrlGenerator("https://example.com", "");
+
+            assertThat(generator.pattern()).isEmpty();
+            assertThat(generator.generateUrl("admin"))
+                    .isEqualTo("https://example.com/admin");
+        }
+
+        @Test
+        void constructor_withValidPattern_storesPatternForRetrieval() {
+            UrlGenerator generator = new UrlGenerator("https://example.com", "/api/{WORD}");
+
+            assertThat(generator.pattern()).contains("/api/{WORD}");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"/api/{WORD}\n", "/api/{WORD}\t", "/api/{WORD}\u0000",
+                "/api/{WORD}\u007F"})
+        void constructor_withControlCharsInPattern_throwsIllegalArgumentException(String badPattern) {
+            // Architect-added behaviour: control chars are rejected on the pattern
+            // itself (not just on entries), preventing pattern-side smuggling of
+            // CR/LF/NUL into generated URLs.
+            assertThatThrownBy(() -> new UrlGenerator("https://example.com", badPattern))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("control character");
+        }
+    }
+
+    @Nested
+    class SimpleGeneration {
+
+        @Test
+        void generateUrl_withNullEntry_throwsNullPointerException() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            assertThatThrownBy(() -> generator.generateUrl(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "   ", "\t", "\n"})
+        void generateUrl_withBlankEntry_throwsIllegalArgumentException(String blank) {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            assertThatThrownBy(() -> generator.generateUrl(blank))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("blank");
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "https://example.com,         admin,        https://example.com/admin",
+                "https://example.com/,        admin,        https://example.com/admin",
+                "https://example.com,         /admin,       https://example.com/admin",
+                "https://example.com/,        /admin,       https://example.com/admin",
+                "https://example.com/api,     users,        https://example.com/api/users",
+                "https://example.com/api/,    users,        https://example.com/api/users",
+                "https://example.com/api,     /users,       https://example.com/api/users",
+                "https://example.com/api/,    /users,       https://example.com/api/users"
+        })
+        void generateUrl_handlesSlashCombinations(String base, String entry, String expected) {
+            UrlGenerator generator = new UrlGenerator(base);
+
+            assertThat(generator.generateUrl(entry)).isEqualTo(expected);
+        }
+
+        @Test
+        void generateUrl_trimsLeadingAndTrailingWhitespace() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            assertThat(generator.generateUrl("  admin  "))
+                    .isEqualTo("https://example.com/admin");
+        }
+
+        @Test
+        void generateUrl_preservesPort() {
+            UrlGenerator generator = new UrlGenerator("https://example.com:8443");
+
+            assertThat(generator.generateUrl("admin"))
+                    .isEqualTo("https://example.com:8443/admin");
+        }
+
+        @Test
+        void generateUrl_preservesQueryAndFragment() {
+            UrlGenerator generator = new UrlGenerator("https://example.com/api?token=abc#frag");
+
+            String url = generator.generateUrl("users");
+
+            assertThat(url).contains("/api/users");
+            assertThat(url).contains("token=abc");
+            assertThat(url).endsWith("#frag");
+        }
+
+        @Test
+        void generateUrl_supportsMultiSegmentEntries() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            assertThat(generator.generateUrl("a/b/c"))
+                    .isEqualTo("https://example.com/a/b/c");
+        }
+
+        @Test
+        void generateUrl_preservesIpv6Host() {
+            UrlGenerator generator = new UrlGenerator("https://[::1]:8080");
+
+            assertThat(generator.generateUrl("admin"))
+                    .isEqualTo("https://[::1]:8080/admin");
+        }
+
+        @Test
+        void generateUrl_preservesUserinfo() {
+            UrlGenerator generator = new UrlGenerator("https://user:pw@example.com");
+
+            assertThat(generator.generateUrl("admin"))
+                    .isEqualTo("https://user:pw@example.com/admin");
+        }
+    }
+
+    @Nested
+    class Normalization {
+
+        @Test
+        void generateUrl_collapsesDuplicateSlashesInEntry() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            assertThat(generator.generateUrl("a//b///c"))
+                    .isEqualTo("https://example.com/a/b/c");
+        }
+
+        @Test
+        void generateUrl_doesNotCollapseSchemeSlashes() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            String url = generator.generateUrl("admin");
+
+            assertThat(url).startsWith("https://");
+        }
+
+        @Test
+        void generateUrl_collapsesBoundarySlashes() {
+            UrlGenerator generator = new UrlGenerator("https://example.com/api/");
+
+            assertThat(generator.generateUrl("///users"))
+                    .isEqualTo("https://example.com/api/users");
+        }
+    }
+
+    @Nested
+    class Encoding {
+
+        @Test
+        void generateUrl_percentEncodesSpaces() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            assertThat(generator.generateUrl("hello world"))
+                    .isEqualTo("https://example.com/hello%20world");
+        }
+
+        @Test
+        void generateUrl_percentEncodesUnicode() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            String url = generator.generateUrl("caf\u00e9");
+
+            assertThat(url).isEqualTo("https://example.com/caf%C3%A9");
+        }
+
+        @Test
+        void generateUrl_preservesUnreservedCharacters() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            assertThat(generator.generateUrl("ABC-abc_123.~"))
+                    .isEqualTo("https://example.com/ABC-abc_123.~");
+        }
+    }
+
+    @Nested
+    class ControlCharacterRejection {
+
+        // Architect-added behaviour: every character below U+0020 and U+007F (DEL)
+        // must be rejected explicitly rather than silently percent-encoded, so a
+        // malicious wordlist cannot smuggle CRLF or NUL into downstream HTTP.
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "ad\u0000min",    // NUL
+                "ad\u0001min",    // SOH
+                "ad\rmin",        // CR
+                "ad\nmin",        // LF
+                "ad\r\nmin",      // CRLF (the canonical request-smuggling vector)
+                "ad\u001Fmin",    // boundary: just below U+0020
+                "ad\u007Fmin"     // DEL
+        })
+        void generateUrl_withControlCharInEntry_throwsIllegalArgumentException(String entry) {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            assertThatThrownBy(() -> generator.generateUrl(entry))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("control character");
+        }
+
+        @Test
+        void generateUrl_atSpaceBoundary_isNotRejectedAsControlChar() {
+            // U+0020 (space) is the lowest non-control character — it must encode,
+            // not throw. Guards against off-by-one in the < 0x20 check.
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            assertThat(generator.generateUrl("hello world"))
+                    .isEqualTo("https://example.com/hello%20world");
+        }
+
+        @Test
+        void generateUrl_at0x7EBoundary_isNotRejectedAsControlChar() {
+            // U+007E (~) is just below DEL (U+007F) — it must be preserved.
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            assertThat(generator.generateUrl("a~b"))
+                    .isEqualTo("https://example.com/a~b");
+        }
+    }
+
+    @Nested
+    class PatternSubstitution {
+
+        @Test
+        void generateUrl_substitutesPlaceholderInPattern() {
+            UrlGenerator generator = new UrlGenerator("https://example.com", "/admin/{WORD}");
+
+            assertThat(generator.generateUrl("login"))
+                    .isEqualTo("https://example.com/admin/login");
+        }
+
+        @Test
+        void generateUrl_substitutesMultipleOccurrencesOfPlaceholder() {
+            UrlGenerator generator =
+                    new UrlGenerator("https://example.com", "/{WORD}/admin/{WORD}");
+
+            assertThat(generator.generateUrl("api"))
+                    .isEqualTo("https://example.com/api/admin/api");
+        }
+
+        @Test
+        void generateUrl_patternCanIncludeSuffix() {
+            UrlGenerator generator =
+                    new UrlGenerator("https://example.com", "/api/{WORD}/users.json");
+
+            assertThat(generator.generateUrl("v2"))
+                    .isEqualTo("https://example.com/api/v2/users.json");
+        }
+
+        @Test
+        void generateUrl_patternEntryStillEncoded() {
+            UrlGenerator generator = new UrlGenerator("https://example.com", "/q/{WORD}");
+
+            assertThat(generator.generateUrl("hello world"))
+                    .isEqualTo("https://example.com/q/hello%20world");
+        }
+    }
+
+    @Nested
+    class LengthAndValidation {
+
+        @Test
+        void generateUrl_atMaxLength_succeeds() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+            int basePrefix = "https://example.com/".length();
+            String entry = "a".repeat(UrlGenerator.MAX_URL_LENGTH - basePrefix);
+
+            String url = generator.generateUrl(entry);
+
+            assertThat(url).hasSize(UrlGenerator.MAX_URL_LENGTH);
+        }
+
+        @Test
+        void generateUrl_aboveMaxLength_throwsIllegalArgumentException() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+            String entry = "a".repeat(UrlGenerator.MAX_URL_LENGTH + 1);
+
+            assertThatThrownBy(() -> generator.generateUrl(entry))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("maximum length");
+        }
+
+        @Test
+        void generateUrl_rawEntryAboveMaxLength_isRejectedBeforeBuildingUrl() {
+            // Architect-added pre-check: the cap is also applied to the raw entry
+            // length so a pathological wordlist line cannot force allocation of a
+            // multi-megabyte combined URL string just to fail validation later.
+            // Exercise it with an entry comfortably larger than the cap.
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+            String entry = "a".repeat(UrlGenerator.MAX_URL_LENGTH * 4);
+
+            assertThatThrownBy(() -> generator.generateUrl(entry))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("maximum length");
+        }
+
+        @Test
+        void generateUrl_postBuildLengthCheck_rejectsWhenEntryFitsButResultDoesnt() {
+            // Cover the OTHER branch of the length check: an entry whose own
+            // length is <= MAX_URL_LENGTH but whose combined URL exceeds it
+            // (here the base prefix pushes the total over the cap).
+            UrlGenerator generator = new UrlGenerator("https://example.com/some/longer/prefix");
+            String entry = "a".repeat(UrlGenerator.MAX_URL_LENGTH);
+
+            assertThatThrownBy(() -> generator.generateUrl(entry))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("maximum length");
+        }
+    }
+
+    @Nested
+    class RequestFactory {
+
+        @Test
+        void generateRequest_returnsScanRequestWithExpectedFields() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            ScanRequest request = generator.generateRequest("admin");
+
+            assertThat(request.url()).isEqualTo("https://example.com/admin");
+            assertThat(request.wordlistEntry()).isEqualTo("admin");
+            assertThat(request.baseUrl()).isEqualTo("https://example.com");
+            assertThat(request.id()).isNotNull();
+        }
+
+        @Test
+        void generateRequest_assignsUniqueIds() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            ScanRequest first = generator.generateRequest("a");
+            ScanRequest second = generator.generateRequest("a");
+
+            assertThat(first.id()).isNotEqualTo(second.id());
+        }
+
+        @Test
+        void generateRequests_withNullStream_throwsNullPointerException() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            assertThatThrownBy(() -> generator.generateRequests(null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void generateRequests_mapsEachEntryToScanRequestPreservingOrder() {
+            // Architect-added bulk API: a stream-in / stream-out variant that
+            // composes with WordlistService.readWordlist(). Verify mapping is
+            // 1:1 and order-preserving, since callers rely on positional
+            // correlation with the source wordlist.
+            UrlGenerator generator = new UrlGenerator("https://example.com", "/api/{WORD}");
+
+            List<ScanRequest> requests = generator
+                    .generateRequests(Stream.of("alpha", "bravo", "charlie"))
+                    .toList();
+
+            assertThat(requests).extracting(ScanRequest::url).containsExactly(
+                    "https://example.com/api/alpha",
+                    "https://example.com/api/bravo",
+                    "https://example.com/api/charlie");
+            assertThat(requests).extracting(ScanRequest::wordlistEntry)
+                    .containsExactly("alpha", "bravo", "charlie");
+            assertThat(requests).extracting(ScanRequest::id).doesNotHaveDuplicates();
+        }
+
+        @Test
+        void generateRequests_withEmptyStream_returnsEmptyResult() {
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            List<ScanRequest> requests = generator
+                    .generateRequests(Stream.<String>empty())
+                    .toList();
+
+            assertThat(requests).isEmpty();
+        }
+
+        @Test
+        void generateRequests_propagatesExceptionsFromInvalidEntries() {
+            // Documented contract: malformed entries fail-fast rather than being
+            // silently dropped. Verify the bulk API surfaces the same exception
+            // as generateRequest() rather than swallowing it.
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            // toList() forces terminal evaluation, triggering the lazy map.
+            assertThatThrownBy(() -> generator
+                    .generateRequests(Stream.of("ok", "bad\nentry"))
+                    .toList())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("control character");
+        }
+
+        @Test
+        void generateRequests_isLazy_doesNotInvokePerEntryUntilTerminal() {
+            // The stream returned should be lazy. We verify this by handing in a
+            // stream containing an invalid entry but never running a terminal op
+            // — if mapping were eager, we'd see an exception thrown from the
+            // generateRequests() call itself.
+            UrlGenerator generator = new UrlGenerator("https://example.com");
+
+            Stream<ScanRequest> lazy = generator
+                    .generateRequests(Stream.of("ok", "bad\nentry"));
+
+            // Closing the stream without consuming it must not invoke the mapper.
+            lazy.close();
+        }
+    }
+
+    @Nested
+    class ThreadSafety {
+
+        @Test
+        void generateUrl_isSafeForConcurrentUse() throws Exception {
+            UrlGenerator generator = new UrlGenerator("https://example.com", "/api/{WORD}");
+            int concurrency = 64;
+            int perThread = 250;
+
+            try (var executor = java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor()) {
+                var futures = new java.util.ArrayList<java.util.concurrent.Future<Void>>();
+                for (int i = 0; i < concurrency; i++) {
+                    final int threadIndex = i;
+                    futures.add(executor.submit(() -> {
+                        for (int j = 0; j < perThread; j++) {
+                            String expected = "https://example.com/api/t" + threadIndex + "-" + j;
+                            String url = generator.generateUrl("t" + threadIndex + "-" + j);
+                            // Strong per-call assertion: the result must match the
+                            // exact URL expected for this thread's input. Earlier
+                            // version only checked startsWith(), which would pass
+                            // even if calls returned cross-contaminated results.
+                            assertThat(url).isEqualTo(expected);
+                        }
+                        return null;
+                    }));
+                }
+                for (var f : futures) {
+                    f.get(2, TimeUnit.SECONDS);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/statefulscanner/model/ScanRequestTest.java
+++ b/src/test/java/com/statefulscanner/model/ScanRequestTest.java
@@ -1,0 +1,148 @@
+package com.statefulscanner.model;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
+class ScanRequestTest {
+
+    private static final UUID ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final String URL = "https://example.com/admin";
+    private static final String ENTRY = "admin";
+    private static final String BASE_URL = "https://example.com";
+
+    @Nested
+    class CompactConstructorValidation {
+
+        @Test
+        void constructor_withNullId_throwsNullPointerException() {
+            assertThatThrownBy(() -> new ScanRequest(null, URL, ENTRY, BASE_URL))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("id");
+        }
+
+        @Test
+        void constructor_withNullUrl_throwsNullPointerException() {
+            assertThatThrownBy(() -> new ScanRequest(ID, null, ENTRY, BASE_URL))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("url");
+        }
+
+        @Test
+        void constructor_withNullWordlistEntry_throwsNullPointerException() {
+            assertThatThrownBy(() -> new ScanRequest(ID, URL, null, BASE_URL))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("wordlistEntry");
+        }
+
+        @Test
+        void constructor_withNullBaseUrl_throwsNullPointerException() {
+            assertThatThrownBy(() -> new ScanRequest(ID, URL, ENTRY, null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("baseUrl");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "   ", "\t", "\n"})
+        void constructor_withBlankUrl_throwsIllegalArgumentException(String blankUrl) {
+            assertThatThrownBy(() -> new ScanRequest(ID, blankUrl, ENTRY, BASE_URL))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("blank");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "   ", "\t", "\n"})
+        void constructor_withBlankWordlistEntry_isAccepted(String blankEntry) {
+            // Deliberate, documented contract: unlike url, wordlistEntry is NOT
+            // blank-checked — blank-rejection is the producing layer's job (see
+            // UrlGenerator.generateUrl). Locking this in means a later "make it
+            // consistent with url" change cannot silently tighten the contract.
+            ScanRequest request = new ScanRequest(ID, URL, blankEntry, BASE_URL);
+
+            assertThat(request.wordlistEntry()).isEqualTo(blankEntry);
+        }
+
+        @Test
+        void constructor_withValidArguments_populatesEveryComponent() {
+            ScanRequest request = new ScanRequest(ID, URL, ENTRY, BASE_URL);
+
+            assertThat(request.id()).isEqualTo(ID);
+            assertThat(request.url()).isEqualTo(URL);
+            assertThat(request.wordlistEntry()).isEqualTo(ENTRY);
+            assertThat(request.baseUrl()).isEqualTo(BASE_URL);
+        }
+    }
+
+    @Nested
+    class Factory {
+
+        @Test
+        void of_assignsFreshNonNullId() {
+            ScanRequest request = ScanRequest.of(URL, ENTRY, BASE_URL);
+
+            assertThat(request.id()).isNotNull();
+        }
+
+        @Test
+        void of_assignsUniqueIdPerCall() {
+            ScanRequest first = ScanRequest.of(URL, ENTRY, BASE_URL);
+            ScanRequest second = ScanRequest.of(URL, ENTRY, BASE_URL);
+
+            assertThat(first.id()).isNotEqualTo(second.id());
+        }
+
+        @Test
+        void of_passesThroughUrlEntryAndBaseUrl() {
+            ScanRequest request = ScanRequest.of(URL, ENTRY, BASE_URL);
+
+            assertThat(request.url()).isEqualTo(URL);
+            assertThat(request.wordlistEntry()).isEqualTo(ENTRY);
+            assertThat(request.baseUrl()).isEqualTo(BASE_URL);
+        }
+
+        @Test
+        void of_isNotABackDoorAroundValidation() {
+            // The factory delegates to the compact constructor, so the same
+            // validation must fire: a blank url still fails, a null url still NPEs.
+            assertThatThrownBy(() -> ScanRequest.of("  ", ENTRY, BASE_URL))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("blank");
+            assertThatThrownBy(() -> ScanRequest.of(null, ENTRY, BASE_URL))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("url");
+        }
+    }
+
+    @Nested
+    class Equality {
+
+        @Test
+        void equals_isValueBasedWhenEveryComponentMatches() {
+            ScanRequest a = new ScanRequest(ID, URL, ENTRY, BASE_URL);
+            ScanRequest b = new ScanRequest(ID, URL, ENTRY, BASE_URL);
+
+            assertThat(a).isEqualTo(b);
+            assertThat(a).hasSameHashCodeAs(b);
+        }
+
+        @Test
+        void equals_differsWhenOnlyIdDiffers() {
+            // Documented intent: two requests for the same URL are NOT equal when
+            // their ids differ — the id correlates one specific in-flight attempt
+            // with its eventual response, so it must participate in equality.
+            ScanRequest a = new ScanRequest(UUID.randomUUID(), URL, ENTRY, BASE_URL);
+            ScanRequest b = new ScanRequest(UUID.randomUUID(), URL, ENTRY, BASE_URL);
+
+            assertThat(a).isNotEqualTo(b);
+        }
+    }
+}


### PR DESCRIPTION
Add the producer-consumer plumbing that turns wordlist entries into queued scan requests for HTTP workers.

- UrlGenerator: combines a base URL with wordlist entries, supports the {WORD} pattern placeholder, normalizes slashes, percent-encodes via java.net.URI, rejects control characters (CRLF smuggling guard) and any URL exceeding 8192 characters. Immutable / virtual-thread safe. Exposes a Stream<ScanRequest> bulk API for direct composition with WordlistService.
- RequestQueue: bounded LinkedBlockingQueue<ScanRequest> wrapper with blocking, timed, and non-blocking enqueue/dequeue plus a bounded drainTo overload for batched consumers. No synchronized blocks, so blocking calls do not pin virtual-thread carriers.
- ScanRequest: immutable record (UUID id, url, wordlistEntry, baseUrl) carrying one unit of scan work.

Tests: 110 new tests across UrlGeneratorTest and RequestQueueTest covering construction validation, slash-combination matrix, normalization, encoding, pattern substitution, control-character rejection at every boundary, length pre-check + post-build cap, bulk stream API, all timed/non-blocking variants, drain on partially consumed queues, concurrent producer/consumer correctness with UUID-based exactly-once verification, and bounded-Future.get for blocking assertions instead of sleep.

CLAUDE.md: refresh architecture to include core/ and model/, add the scanner pipeline diagram, document the testing conventions in use across the suite, and surface the checkstyle newline rule.