### PR TITLE
T07: Add Guava-backed rate limiting with CLI configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,19 +39,24 @@ com.statefulscanner/
 ├── StatefulScannerApplication.java   # Entry point
 ├── config/
 │   ├── ExecutorConfig.java           # Virtual thread executor bean + graceful shutdown
-│   └── HttpClientConfig.java         # java.net.http.HttpClient bean (HTTP/2, virtual threads)
+│   ├── HttpClientConfig.java         # java.net.http.HttpClient bean (HTTP/2, virtual threads)
+│   ├── RateLimiterProperties.java    # @ConfigurationProperties record bound to scanner.rate-limiter.* (range [1, 10000], finite-only)
+│   └── RateLimiterConfig.java        # Builds the Guava RateLimiter bean (smooth-bursty, or smooth-warming-up when warmupPeriodSeconds > 0)
 ├── exception/
 │   └── HttpRetryExhaustedException.java  # Thrown when retry attempts are exhausted
 ├── health/
 │   └── VirtualThreadHealthIndicator.java  # HealthIndicator impl — exposed at /actuator/health
 └── service/
     ├── HttpRequestService.java       # Async HTTP GET with retry (IOException/TimeoutException only)
+    ├── RateLimiterService.java       # Wraps Guava RateLimiter — hides @Beta type, validates inputs, exposes acquire/tryAcquire/setRate
     └── WordlistService.java          # Streaming wordlist file reader with dedup and CSV support
 ```
 
 **Concurrency model:** Virtual threads via `Executors.newVirtualThreadPerTaskExecutor()`. One executor bean shared across the app. Graceful shutdown with 30-second timeout in `@PreDestroy`. Avoid `synchronized` blocks — use `java.util.concurrent` structures to prevent virtual thread pinning.
 
-**Testing approach:** `ExecutorConfigTest` is a plain unit test (no Spring context) — instantiates `ExecutorConfig` directly. Use `@SpringBootTest` only when testing Spring wiring. AssertJ is the preferred assertion library.
+**Testing approach:** `ExecutorConfigTest` is a plain unit test (no Spring context) — instantiates `ExecutorConfig` directly. Use `@SpringBootTest` only when testing Spring wiring. AssertJ is the preferred assertion library. Tests that mock final or abstract classes (e.g. Guava `RateLimiter`) use `@ExtendWith(MockitoExtension.class)` + `@Mock`; the Surefire `argLine` in `pom.xml` loads `byte-buddy-agent` as a `-javaagent` so Mockito does not self-attach (silences the JDK 25 dynamic-agent warning).
+
+**Rate limiting:** `--rate=N` CLI shorthand maps to `scanner.rate-limiter.permits-per-second` via a `${rate:100.0}` placeholder in `application.yml`. Range is enforced in `RateLimiterProperties`'s canonical constructor (1–10000, finite-only). Guava's `RateLimiter` is `@Beta` — keep all references to the type confined to `RateLimiterConfig` and `RateLimiterService` so it can be swapped (e.g. for Resilience4j) without touching callers.
 
 ## Dependencies
 
@@ -59,4 +64,6 @@ com.statefulscanner/
 - `spring-boot-starter-data-jpa` — Hibernate + Spring Data JPA
 - `spring-boot-starter-actuator` — Health checks, metrics, `/actuator/health` endpoint
 - `spring-boot-starter-test` — JUnit 5 + Mockito + AssertJ (test scope)
+- `byte-buddy-agent` — Loaded as `-javaagent` by Surefire so Mockito can mock abstract/final classes without self-attaching (test scope)
+- `guava` (`33.0.0-jre`) — Provides `RateLimiter` for request pacing
 - `h2` — In-memory database (runtime scope)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ com.statefulscanner/
 
 **Testing approach:** `ExecutorConfigTest` is a plain unit test (no Spring context) — instantiates `ExecutorConfig` directly. Use `@SpringBootTest` only when testing Spring wiring. AssertJ is the preferred assertion library. Tests that mock final or abstract classes (e.g. Guava `RateLimiter`) use `@ExtendWith(MockitoExtension.class)` + `@Mock`; the Surefire `argLine` in `pom.xml` loads `byte-buddy-agent` as a `-javaagent` so Mockito does not self-attach (silences the JDK 25 dynamic-agent warning).
 
-**Rate limiting:** `--rate=N` CLI shorthand maps to `scanner.rate-limiter.permits-per-second` via a `${rate:100.0}` placeholder in `application.yml`. Range is enforced in `RateLimiterProperties`'s canonical constructor (1–10000, finite-only). Guava's `RateLimiter` is `@Beta` — keep all references to the type confined to `RateLimiterConfig` and `RateLimiterService` so it can be swapped (e.g. for Resilience4j) without touching callers.
+**Rate limiting:** `--rate=N` CLI shorthand maps to `scanner.rate-limiter.permits-per-second` via a `${rate:100.0}` placeholder in `application.yml`; `--rate-warmup=N` likewise maps to `scanner.rate-limiter.warmup-period-seconds` via `${rate-warmup:0.0}` (cold-start ramp window in seconds; `0` disables warmup). Range is enforced in `RateLimiterProperties`'s canonical constructor (1–10000, finite-only). Guava's `RateLimiter` is `@Beta` — keep all references to the type confined to `RateLimiterConfig` and `RateLimiterService` so it can be swapped (e.g. for Resilience4j) without touching callers.
 
 ## Dependencies
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,21 @@
         </dependency>
 
         <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.0.0-jre</version>
         </dependency>
     </dependencies>
 
@@ -52,6 +64,20 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--
+                        @{argLine} preserves Jacoco's prepare-agent contribution.
+                        Loading byte-buddy-agent as a -javaagent silences the JDK 25 warning
+                        about Mockito's dynamic agent self-attachment and stays compatible
+                        with the future "dynamic agents disallowed by default" change.
+                    -->
+                    <argLine>@{argLine} -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar</argLine>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/src/main/java/com/statefulscanner/config/RateLimiterConfig.java
+++ b/src/main/java/com/statefulscanner/config/RateLimiterConfig.java
@@ -1,0 +1,50 @@
+package com.statefulscanner.config;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * Wires Guava's {@link RateLimiter} as a Spring bean using settings from
+ * {@link RateLimiterProperties}.
+ *
+ * <p>When {@code warmupPeriodSeconds == 0} a smooth-bursty limiter is built.
+ * Otherwise a smooth-warming-up limiter is built that ramps from a slower cold rate
+ * to the configured rate over the warmup window — useful for not flooding a target
+ * server the moment a scan begins.
+ *
+ * <p><strong>Note on {@code @Beta}:</strong> Guava's {@code RateLimiter} is annotated
+ * {@code @Beta}. The wrapping {@link com.statefulscanner.service.RateLimiterService}
+ * exists precisely to keep that type out of the rest of the codebase so it can be
+ * swapped for a stable alternative (e.g. Resilience4j) without rippling through callers.
+ */
+@Configuration
+@EnableConfigurationProperties(RateLimiterProperties.class)
+public class RateLimiterConfig {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RateLimiterConfig.class);
+
+    @Bean
+    @SuppressWarnings("UnstableApiUsage")
+    public RateLimiter rateLimiter(RateLimiterProperties properties) {
+        double rps = properties.permitsPerSecond();
+        double warmupSeconds = properties.warmupPeriodSeconds();
+
+        if (warmupSeconds > 0.0) {
+            Duration warmup = Duration.ofNanos((long) (warmupSeconds * 1_000_000_000.0));
+            RateLimiter limiter = RateLimiter.create(rps, warmup);
+            LOG.info("RateLimiter created: {} permits/sec with {}s warmup (smooth-warming-up)",
+                    rps, warmupSeconds);
+            return limiter;
+        }
+
+        RateLimiter limiter = RateLimiter.create(rps);
+        LOG.info("RateLimiter created: {} permits/sec (smooth-bursty, no warmup)", rps);
+        return limiter;
+    }
+}

--- a/src/main/java/com/statefulscanner/config/RateLimiterProperties.java
+++ b/src/main/java/com/statefulscanner/config/RateLimiterProperties.java
@@ -1,0 +1,46 @@
+package com.statefulscanner.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * Configuration for the request rate limiter.
+ *
+ * <p>Bound from the {@code scanner.rate-limiter.*} property namespace. The default
+ * {@code application.yml} wires {@code permits-per-second} to the {@code --rate}
+ * command-line shorthand via a placeholder, so both
+ * {@code --rate=500} and {@code --scanner.rate-limiter.permits-per-second=500}
+ * select the same setting.
+ *
+ * @param permitsPerSecond     target steady-state request rate.
+ *                             Must be in [1, 10000]; defaults to 100.
+ * @param warmupPeriodSeconds  cold-start ramp-up window. {@code 0} disables warmup
+ *                             (smooth-bursty mode); a positive value selects Guava's
+ *                             smooth-warming-up mode where the first permit is slower
+ *                             and the rate ramps up linearly until the steady rate is
+ *                             reached after {@code warmupPeriodSeconds}.
+ *                             Must be {@code >= 0}; defaults to 0.
+ */
+@ConfigurationProperties(prefix = "scanner.rate-limiter")
+public record RateLimiterProperties(
+        @DefaultValue("100.0") double permitsPerSecond,
+        @DefaultValue("0.0") double warmupPeriodSeconds) {
+
+    public static final double MIN_PERMITS_PER_SECOND = 1.0;
+    public static final double MAX_PERMITS_PER_SECOND = 10_000.0;
+
+    public RateLimiterProperties {
+        if (!Double.isFinite(permitsPerSecond)
+                || permitsPerSecond < MIN_PERMITS_PER_SECOND
+                || permitsPerSecond > MAX_PERMITS_PER_SECOND) {
+            throw new IllegalArgumentException(
+                    "scanner.rate-limiter.permits-per-second must be finite and in [%s, %s], got: %s"
+                            .formatted(MIN_PERMITS_PER_SECOND, MAX_PERMITS_PER_SECOND, permitsPerSecond));
+        }
+        if (!Double.isFinite(warmupPeriodSeconds) || warmupPeriodSeconds < 0.0) {
+            throw new IllegalArgumentException(
+                    "scanner.rate-limiter.warmup-period-seconds must be finite and >= 0, got: "
+                            + warmupPeriodSeconds);
+        }
+    }
+}

--- a/src/main/java/com/statefulscanner/config/RateLimiterProperties.java
+++ b/src/main/java/com/statefulscanner/config/RateLimiterProperties.java
@@ -12,6 +12,14 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  * {@code --rate=500} and {@code --scanner.rate-limiter.permits-per-second=500}
  * select the same setting.
  *
+ * <p><strong>Bound asymmetry:</strong> the {@code [1, 10000]} range checked by
+ * this record's canonical constructor constrains <em>startup</em> configuration
+ * only. The runtime
+ * {@link com.statefulscanner.service.RateLimiterService#setRate(double)} path
+ * intentionally accepts any positive, finite rate so adaptive throttling can move
+ * outside this range in response to target behaviour. That looser runtime bound
+ * is by design — do not tighten it to match.
+ *
  * @param permitsPerSecond     target steady-state request rate.
  *                             Must be in [1, 10000]; defaults to 100.
  * @param warmupPeriodSeconds  cold-start ramp-up window. {@code 0} disables warmup

--- a/src/main/java/com/statefulscanner/service/RateLimiterService.java
+++ b/src/main/java/com/statefulscanner/service/RateLimiterService.java
@@ -1,0 +1,129 @@
+package com.statefulscanner.service;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thin wrapper around Guava's {@link RateLimiter} that hides the {@code @Beta} type
+ * from callers and provides a stable surface for rate-limited request pacing.
+ *
+ * <p>This service is thread-safe: the underlying {@code RateLimiter} synchronises
+ * internally, so multiple virtual threads may call {@link #acquire()} concurrently
+ * and will be paced fairly across the shared rate budget.
+ *
+ * <p><strong>Virtual-thread note:</strong> Guava's {@code RateLimiter} synchronises
+ * on a short internal monitor while computing the next permit. On Java 25 (JEP 491)
+ * virtual threads no longer pin their carrier while holding monitors, so this
+ * critical section is safe under heavy virtual-thread fan-out. The wait inside
+ * {@link #acquire()} is implemented by Guava as an <em>uninterruptible</em> sleep
+ * (interrupts are absorbed and the flag is restored on return), so callers cannot
+ * cancel an in-flight {@code acquire()} via {@code Thread.interrupt()}; use
+ * {@link #tryAcquire(Duration)} with a bounded timeout for cancellable flows.
+ *
+ * <h2>Typical usage</h2>
+ * <pre>{@code
+ * rateLimiterService.acquire();   // blocks until a permit is available
+ * httpClient.get(url);            // dispatch under the rate budget
+ * }</pre>
+ *
+ * <p>For non-blocking flows (e.g. an event loop), prefer
+ * {@link #tryAcquire(Duration)} with a short timeout and back off on failure.
+ */
+@Service
+@SuppressWarnings("UnstableApiUsage")
+public class RateLimiterService {
+
+    private final RateLimiter rateLimiter;
+
+    public RateLimiterService(RateLimiter rateLimiter) {
+        this.rateLimiter = rateLimiter;
+    }
+
+    /**
+     * Blocks until a single permit is available.
+     *
+     * @return the number of seconds the caller waited (0.0 if the permit was immediate)
+     */
+    public double acquire() {
+        return rateLimiter.acquire();
+    }
+
+    /**
+     * Blocks until {@code permits} permits are available.
+     *
+     * @param permits number of permits to acquire; must be positive
+     * @return the number of seconds the caller waited (0.0 if granted immediately)
+     * @throws IllegalArgumentException if {@code permits} is not positive
+     */
+    public double acquire(int permits) {
+        if (permits <= 0) {
+            throw new IllegalArgumentException("permits must be positive, got: " + permits);
+        }
+        return rateLimiter.acquire(permits);
+    }
+
+    /**
+     * Attempts to acquire a single permit without blocking.
+     *
+     * @return {@code true} if a permit was available immediately, {@code false} otherwise
+     */
+    public boolean tryAcquire() {
+        return rateLimiter.tryAcquire();
+    }
+
+    /**
+     * Attempts to acquire a single permit, waiting up to {@code timeout}.
+     *
+     * <p>A negative or zero timeout is treated as a non-blocking probe.
+     *
+     * @param timeout the maximum time to wait
+     * @return {@code true} if the permit was acquired within the timeout, {@code false} otherwise
+     * @throws NullPointerException if {@code timeout} is {@code null}
+     */
+    public boolean tryAcquire(Duration timeout) {
+        Objects.requireNonNull(timeout, "timeout must not be null");
+        return rateLimiter.tryAcquire(timeout);
+    }
+
+    /**
+     * Attempts to acquire a single permit, waiting up to the given timeout.
+     *
+     * @param timeout the maximum time to wait; negative values are treated as zero
+     * @param unit    the time unit of {@code timeout}
+     * @return {@code true} if the permit was acquired within the timeout, {@code false} otherwise
+     * @throws NullPointerException if {@code unit} is {@code null}
+     */
+    public boolean tryAcquire(long timeout, TimeUnit unit) {
+        Objects.requireNonNull(unit, "unit must not be null");
+        return rateLimiter.tryAcquire(timeout, unit);
+    }
+
+    /**
+     * Adjusts the steady-state permit rate at runtime.
+     *
+     * <p>Permits already in flight are not affected. The new rate takes effect for
+     * the next acquisition. Useful for adaptive scanning that slows down on
+     * 429/503 responses or speeds up when a target proves resilient.
+     *
+     * @param permitsPerSecond new target rate; must be positive and finite
+     * @throws IllegalArgumentException if {@code permitsPerSecond} is not positive or is not finite
+     */
+    public void setRate(double permitsPerSecond) {
+        if (!(permitsPerSecond > 0.0) || Double.isInfinite(permitsPerSecond)) {
+            throw new IllegalArgumentException(
+                    "permitsPerSecond must be positive and finite, got: " + permitsPerSecond);
+        }
+        rateLimiter.setRate(permitsPerSecond);
+    }
+
+    /**
+     * @return the currently configured permit rate (permits per second)
+     */
+    public double getRate() {
+        return rateLimiter.getRate();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,13 @@ spring:
 server:
   port: 8080
 
+scanner:
+  rate-limiter:
+    # CLI shorthand --rate=N is wired here. Range [1, 10000]; default 100.
+    permits-per-second: ${rate:100.0}
+    # Cold-start ramp window in seconds; 0 disables warmup.
+    warmup-period-seconds: ${rate-warmup:0.0}
+
 management:
   endpoints:
     web:

--- a/src/test/java/com/statefulscanner/config/RateLimiterConfigTest.java
+++ b/src/test/java/com/statefulscanner/config/RateLimiterConfigTest.java
@@ -1,0 +1,85 @@
+package com.statefulscanner.config;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("UnstableApiUsage")
+class RateLimiterConfigTest {
+
+    private final RateLimiterConfig config = new RateLimiterConfig();
+
+    @Test
+    void rateLimiter_withNoWarmup_returnsLimiterAtConfiguredRate() {
+        var props = new RateLimiterProperties(250.0, 0.0);
+
+        RateLimiter limiter = config.rateLimiter(props);
+
+        assertThat(limiter).isNotNull();
+        assertThat(limiter.getRate()).isEqualTo(250.0);
+    }
+
+    @Test
+    void rateLimiter_withWarmup_returnsLimiterAtConfiguredSteadyRate() {
+        var props = new RateLimiterProperties(500.0, 1.5);
+
+        RateLimiter limiter = config.rateLimiter(props);
+
+        assertThat(limiter).isNotNull();
+        assertThat(limiter.getRate())
+                .as("Steady-state rate should match config regardless of warmup mode")
+                .isEqualTo(500.0);
+    }
+
+    @Test
+    void rateLimiter_atMinimumRate_isCreated() {
+        var props = new RateLimiterProperties(1.0, 0.0);
+
+        RateLimiter limiter = config.rateLimiter(props);
+
+        assertThat(limiter.getRate()).isEqualTo(1.0);
+    }
+
+    @Test
+    void rateLimiter_atMaximumRate_isCreated() {
+        var props = new RateLimiterProperties(10_000.0, 0.0);
+
+        RateLimiter limiter = config.rateLimiter(props);
+
+        assertThat(limiter.getRate()).isEqualTo(10_000.0);
+    }
+
+    @Test
+    void rateLimiter_eachInvocation_returnsDistinctInstance() {
+        var props = new RateLimiterProperties(100.0, 0.0);
+
+        RateLimiter first = config.rateLimiter(props);
+        RateLimiter second = config.rateLimiter(props);
+
+        assertThat(first).isNotSameAs(second);
+    }
+
+    @Test
+    void rateLimiter_withZeroWarmup_returnsBurstyLimiterImplementation() {
+        var props = new RateLimiterProperties(500.0, 0.0);
+
+        RateLimiter limiter = config.rateLimiter(props);
+
+        assertThat(limiter.getClass().getSimpleName())
+                .as("warmup=0 must select Guava's smooth-bursty limiter")
+                .isEqualTo("SmoothBursty");
+    }
+
+    @Test
+    void rateLimiter_withPositiveWarmup_returnsWarmingUpLimiterImplementation() {
+        var props = new RateLimiterProperties(500.0, 1.5);
+
+        RateLimiter limiter = config.rateLimiter(props);
+
+        assertThat(limiter.getClass().getSimpleName())
+                .as("warmup>0 must select Guava's smooth-warming-up limiter")
+                .isEqualTo("SmoothWarmingUp");
+    }
+}
+

--- a/src/test/java/com/statefulscanner/config/RateLimiterConfigTest.java
+++ b/src/test/java/com/statefulscanner/config/RateLimiterConfigTest.java
@@ -60,6 +60,10 @@ class RateLimiterConfigTest {
         assertThat(first).isNotSameAs(second);
     }
 
+    // The next two tests assert on Guava's internal limiter class names
+    // (SmoothBursty / SmoothWarmingUp). The coupling is deliberate: both modes
+    // report the same getRate(), so the class name is the only observable signal
+    // that RateLimiterConfig selected the correct branch for the warmup setting.
     @Test
     void rateLimiter_withZeroWarmup_returnsBurstyLimiterImplementation() {
         var props = new RateLimiterProperties(500.0, 0.0);

--- a/src/test/java/com/statefulscanner/config/RateLimiterPropertiesTest.java
+++ b/src/test/java/com/statefulscanner/config/RateLimiterPropertiesTest.java
@@ -1,0 +1,113 @@
+package com.statefulscanner.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RateLimiterPropertiesTest {
+
+    @Test
+    void constructor_atLowerBoundOnePermitPerSecond_isAccepted() {
+        var props = new RateLimiterProperties(1.0, 0.0);
+
+        assertThat(props.permitsPerSecond()).isEqualTo(1.0);
+        assertThat(props.warmupPeriodSeconds()).isZero();
+    }
+
+    @Test
+    void constructor_atUpperBoundTenThousandPermits_isAccepted() {
+        var props = new RateLimiterProperties(10_000.0, 0.0);
+
+        assertThat(props.permitsPerSecond()).isEqualTo(10_000.0);
+    }
+
+    @Test
+    void constructor_typicalValues_areAccepted() {
+        var props = new RateLimiterProperties(100.0, 2.5);
+
+        assertThat(props.permitsPerSecond()).isEqualTo(100.0);
+        assertThat(props.warmupPeriodSeconds()).isEqualTo(2.5);
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {0.0, 0.99, -1.0, -100.0, 10_000.01, 1_000_000.0})
+    void constructor_permitsPerSecondOutOfRange_throwsIllegalArgumentException(double rate) {
+        assertThatThrownBy(() -> new RateLimiterProperties(rate, 0.0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("permits-per-second")
+                .hasMessageContaining(String.valueOf(rate));
+    }
+
+    @Test
+    void constructor_permitsPerSecondNaN_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> new RateLimiterProperties(Double.NaN, 0.0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("permits-per-second")
+                .hasMessageContaining("finite");
+    }
+
+    @Test
+    void constructor_permitsPerSecondPositiveInfinity_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> new RateLimiterProperties(Double.POSITIVE_INFINITY, 0.0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("permits-per-second")
+                .hasMessageContaining("finite");
+    }
+
+    @Test
+    void constructor_permitsPerSecondNegativeInfinity_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> new RateLimiterProperties(Double.NEGATIVE_INFINITY, 0.0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("permits-per-second")
+                .hasMessageContaining("finite");
+    }
+
+    @Test
+    void constructor_warmupZero_isAccepted() {
+        var props = new RateLimiterProperties(100.0, 0.0);
+
+        assertThat(props.warmupPeriodSeconds()).isZero();
+    }
+
+    @Test
+    void constructor_warmupPositive_isAccepted() {
+        var props = new RateLimiterProperties(100.0, 30.0);
+
+        assertThat(props.warmupPeriodSeconds()).isEqualTo(30.0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {-0.01, -1.0, -1_000.0})
+    void constructor_warmupNegative_throwsIllegalArgumentException(double warmup) {
+        assertThatThrownBy(() -> new RateLimiterProperties(100.0, warmup))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("warmup-period-seconds")
+                .hasMessageContaining(String.valueOf(warmup));
+    }
+
+    @Test
+    void constructor_warmupNaN_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> new RateLimiterProperties(100.0, Double.NaN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("warmup-period-seconds")
+                .hasMessageContaining("finite");
+    }
+
+    @Test
+    void constructor_warmupPositiveInfinity_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> new RateLimiterProperties(100.0, Double.POSITIVE_INFINITY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("warmup-period-seconds")
+                .hasMessageContaining("finite");
+    }
+
+    @Test
+    void boundsConstants_haveExpectedValues() {
+        assertThat(RateLimiterProperties.MIN_PERMITS_PER_SECOND).isEqualTo(1.0);
+        assertThat(RateLimiterProperties.MAX_PERMITS_PER_SECOND).isEqualTo(10_000.0);
+    }
+}
+

--- a/src/test/java/com/statefulscanner/service/RateLimiterServiceTest.java
+++ b/src/test/java/com/statefulscanner/service/RateLimiterServiceTest.java
@@ -1,0 +1,314 @@
+package com.statefulscanner.service;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RateLimiterServiceTest {
+
+    @Mock
+    @SuppressWarnings("UnstableApiUsage")
+    private RateLimiter mockLimiter;
+
+    private RateLimiterService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RateLimiterService(mockLimiter);
+    }
+
+    // --- delegation: acquire() ---
+
+    @Test
+    void acquire_delegatesToUnderlyingLimiter() {
+        when(mockLimiter.acquire()).thenReturn(0.5);
+
+        double waited = service.acquire();
+
+        assertThat(waited).isEqualTo(0.5);
+        verify(mockLimiter).acquire();
+    }
+
+    // --- delegation: acquire(int) ---
+
+    @Test
+    void acquireWithPermits_delegatesToUnderlyingLimiter() {
+        when(mockLimiter.acquire(3)).thenReturn(0.25);
+
+        double waited = service.acquire(3);
+
+        assertThat(waited).isEqualTo(0.25);
+        verify(mockLimiter).acquire(3);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
+    void acquireWithPermits_whenNonPositive_throwsAndDoesNotDelegate(int permits) {
+        assertThatThrownBy(() -> service.acquire(permits))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("permits must be positive")
+                .hasMessageContaining(String.valueOf(permits));
+
+        verify(mockLimiter, never()).acquire(anyInt());
+    }
+
+    // --- delegation: tryAcquire() ---
+
+    @Test
+    void tryAcquire_delegatesToUnderlyingLimiter() {
+        when(mockLimiter.tryAcquire()).thenReturn(true);
+
+        boolean result = service.tryAcquire();
+
+        assertThat(result).isTrue();
+        verify(mockLimiter).tryAcquire();
+    }
+
+    @Test
+    void tryAcquire_whenLimiterReturnsFalse_propagatesFalse() {
+        when(mockLimiter.tryAcquire()).thenReturn(false);
+
+        assertThat(service.tryAcquire()).isFalse();
+    }
+
+    // --- delegation: tryAcquire(Duration) ---
+
+    @Test
+    void tryAcquireDuration_delegatesToUnderlyingLimiter() {
+        Duration timeout = Duration.ofMillis(250);
+        when(mockLimiter.tryAcquire(timeout)).thenReturn(true);
+
+        assertThat(service.tryAcquire(timeout)).isTrue();
+        verify(mockLimiter).tryAcquire(timeout);
+    }
+
+    @Test
+    void tryAcquireDuration_whenNull_throwsNpeAndDoesNotDelegate() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> service.tryAcquire((Duration) null))
+                .withMessageContaining("timeout");
+
+        verify(mockLimiter, never()).tryAcquire(any(Duration.class));
+    }
+
+    // --- delegation: tryAcquire(long, TimeUnit) ---
+
+    @Test
+    void tryAcquireTimeoutUnit_delegatesToUnderlyingLimiter() {
+        when(mockLimiter.tryAcquire(100L, TimeUnit.MILLISECONDS)).thenReturn(true);
+
+        assertThat(service.tryAcquire(100L, TimeUnit.MILLISECONDS)).isTrue();
+        verify(mockLimiter).tryAcquire(100L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void tryAcquireTimeoutUnit_whenUnitNull_throwsNpeAndDoesNotDelegate() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> service.tryAcquire(100L, null))
+                .withMessageContaining("unit");
+
+        verify(mockLimiter, never()).tryAcquire(anyLong(), any(TimeUnit.class));
+    }
+
+    @Test
+    void tryAcquireTimeoutUnit_withNegativeTimeout_returnsImmediatelyWithoutWaiting() {
+        // Pass-through to Guava, which treats negative as "no wait" — wrapper does NOT reject.
+        when(mockLimiter.tryAcquire(eq(-1L), eq(TimeUnit.MILLISECONDS))).thenReturn(false);
+
+        assertThat(service.tryAcquire(-1L, TimeUnit.MILLISECONDS)).isFalse();
+    }
+
+    // --- setRate validation + delegation ---
+
+    @Test
+    void setRate_withPositiveFiniteValue_delegatesToUnderlyingLimiter() {
+        service.setRate(250.0);
+
+        verify(mockLimiter).setRate(250.0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {0.0, -0.0, -1.0, -100.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN})
+    void setRate_withInvalidValue_throwsAndDoesNotDelegate(double rate) {
+        assertThatThrownBy(() -> service.setRate(rate))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("permitsPerSecond");
+
+        verifyNoInteractions(mockLimiter);
+    }
+
+    // --- getRate ---
+
+    @Test
+    void getRate_delegatesToUnderlyingLimiter() {
+        when(mockLimiter.getRate()).thenReturn(123.0);
+
+        assertThat(service.getRate()).isEqualTo(123.0);
+    }
+
+    // --- real-limiter behavior ---
+    //
+    // Guava's SmoothBursty stores up to maxBurstSeconds*rate permits between create-time
+    // and the first acquire, so every timed test below drains the burst budget BEFORE
+    // sampling the start clock. The lower-bound assertions then exercise actual pacing,
+    // not accumulated free credit.
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @SuppressWarnings("UnstableApiUsage")
+    void acquire_withRealLimiter_pacesSequentialCallsAtConfiguredRate() {
+        RateLimiter realLimiter = RateLimiter.create(20.0); // 50ms per permit
+        var realService = new RateLimiterService(realLimiter);
+        int permitCount = 5;
+
+        // Drain any stored permits (and the free first permit) before the timed window.
+        while (realService.tryAcquire()) {
+            // burn it
+        }
+
+        long startNanos = System.nanoTime();
+        for (int i = 0; i < permitCount; i++) {
+            realService.acquire();
+        }
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+
+        long expectedMinMs = permitCount * 1_000L / 20L; // 250ms — every permit is paced
+        assertThat(elapsedMs)
+                .as("Sequential acquires should pace at ~rate; expected >= %d ms", expectedMinMs)
+                .isGreaterThanOrEqualTo(expectedMinMs - 20L);
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @SuppressWarnings("UnstableApiUsage")
+    void setRate_withRealLimiter_changesEffectiveRate() {
+        RateLimiter realLimiter = RateLimiter.create(1.0);
+        var realService = new RateLimiterService(realLimiter);
+
+        assertThat(realService.getRate()).isEqualTo(1.0);
+
+        realService.setRate(50.0);
+
+        assertThat(realService.getRate()).isEqualTo(50.0);
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    @SuppressWarnings("UnstableApiUsage")
+    void acquire_underConcurrentVirtualThreadFanOut_paceIsSharedAcrossThreads() throws InterruptedException {
+        RateLimiter realLimiter = RateLimiter.create(50.0); // 50 permits/sec
+        var realService = new RateLimiterService(realLimiter);
+        int threadCount = 20;
+        int permitsPerThread = 5;
+        int totalPermits = threadCount * permitsPerThread; // 100
+
+        try (ExecutorService vtPool = Executors.newVirtualThreadPerTaskExecutor()) {
+            var ready = new CountDownLatch(threadCount);
+            var go = new CountDownLatch(1);
+            var acquired = new AtomicInteger();
+
+            for (int i = 0; i < threadCount; i++) {
+                vtPool.submit(() -> {
+                    ready.countDown();
+                    try {
+                        go.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    for (int p = 0; p < permitsPerThread; p++) {
+                        realService.acquire();
+                        acquired.incrementAndGet();
+                    }
+                });
+            }
+
+            assertThat(ready.await(2, TimeUnit.SECONDS)).isTrue();
+
+            // Drain accumulated burst credit immediately before the timed window opens.
+            while (realService.tryAcquire()) {
+                // burn it
+            }
+
+            long startNanos = System.nanoTime();
+            go.countDown();
+            vtPool.shutdown();
+            assertThat(vtPool.awaitTermination(8, TimeUnit.SECONDS)).isTrue();
+            long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+
+            assertThat(acquired.get()).isEqualTo(totalPermits);
+
+            long expectedMinMs = totalPermits * 1_000L / 50L; // 2000ms — every permit is paced
+            assertThat(elapsedMs)
+                    .as("Concurrent acquires must respect the shared rate budget (>= %d ms)", expectedMinMs)
+                    .isGreaterThanOrEqualTo(expectedMinMs - 100L);
+        }
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @SuppressWarnings("UnstableApiUsage")
+    void tryAcquireDuration_withRealLimiter_andTinyTimeout_returnsFalseWhenStarved() {
+        RateLimiter realLimiter = RateLimiter.create(2.0); // 500ms per permit
+        var realService = new RateLimiterService(realLimiter);
+
+        // Drain *all* stored permits — bursty limiters can hold up to maxBurstSeconds*rate.
+        while (realService.tryAcquire()) {
+            // burn it
+        }
+
+        // 10ms is far less than the 500ms it takes to mint the next permit.
+        boolean acquired = realService.tryAcquire(Duration.ofMillis(10));
+
+        assertThat(acquired).isFalse();
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @SuppressWarnings("UnstableApiUsage")
+    void tryAcquireDuration_withRealLimiter_andSufficientTimeout_returnsTrueAfterRealWait() {
+        RateLimiter realLimiter = RateLimiter.create(100.0); // 10ms per permit
+        var realService = new RateLimiterService(realLimiter);
+
+        // Drain stored permits so the timed call must actually wait for a fresh permit.
+        while (realService.tryAcquire()) {
+            // burn it
+        }
+
+        long startNanos = System.nanoTime();
+        boolean acquired = realService.tryAcquire(Duration.ofMillis(500));
+        long waitedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+
+        assertThat(acquired).isTrue();
+        assertThat(waitedMs)
+                .as("Should have actually paused for ~1 period (10ms) before acquiring")
+                .isGreaterThanOrEqualTo(5L); // half of 10ms — generous slack for clock resolution
+    }
+}
+


### PR DESCRIPTION
- RateLimiterProperties: @ConfigurationProperties record bound to scanner.rate-limiter.*, validates [1, 10000] and finite-only in the canonical constructor.
- RateLimiterConfig: builds the Guava RateLimiter bean — smooth-bursty by default, smooth-warming-up when warmupPeriodSeconds > 0.
- RateLimiterService: thin @Service wrapping Guava's @Beta RateLimiter, exposes acquire / acquire(int) / tryAcquire(...) / setRate / getRate with input validation; isolates the @Beta type for future swap.
- application.yml: --rate=N CLI shorthand maps to permits-per-second via \${rate:100.0} placeholder.
- pom.xml: Guava 33.0.0-jre, byte-buddy-agent (test) + Surefire argLine loading it as -javaagent (silences JDK 25 dynamic-agent warning, forward-compatible with future "no dynamic agents" default).
- Tests: 53 new (RateLimiterPropertiesTest 20, RateLimiterConfigTest 7, RateLimiterServiceTest 26). Mockito delegation + real-RateLimiter pacing/concurrency on virtual threads with stored-permit drains before every timed assertion. 100% instruction & branch coverage on all three new classes.
- CLAUDE.md: architecture tree, dependencies, and a Mockito + rate- limiting note added.